### PR TITLE
Fix lintian warnings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.3.1) stable; urgency=medium
+
+  * Fix lintian warnings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 08 Aug 2025 17:10:00 +0400
+
 wb-mqtt-alice (0.3.0) stable; urgency=medium
 
   * Add Nginx proxy configuration

--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,8 @@ Build-Depends: debhelper (>= 11.0.0),
                python3-setuptools
 Standards-Version: 4.5.1
 X-Python3-Version: >= 3.5
-Homepage: https://github.com/wirenboard/wb-alice-client
-Vcs-Git: https://github.com/wirenboard/wb-alice-client
+Homepage: https://github.com/wirenboard/wb-mqtt-alice
+Vcs-Git: https://github.com/wirenboard/wb-mqtt-alice
 Rules-Requires-Root: no
 
 Package: wb-mqtt-alice

--- a/debian/postrm
+++ b/debian/postrm
@@ -51,8 +51,8 @@ reload_nginx() {
         return 1
     fi
 
-    if systemctl is-active nginx >/dev/null 2>&1; then
-        systemctl reload nginx
+    if deb-systemd-invoke is-active nginx >/dev/null 2>&1; then
+        deb-systemd-invoke reload nginx
         log_info "nginx reloaded"
     else
         log_info "nginx not running, skipping reload"
@@ -85,3 +85,5 @@ main() {
 }
 
 main "${@}"
+
+#DEBHELPER#

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 setup(
@@ -17,7 +17,7 @@ setup(
     author_email="vitalii.gaponov@wirenboard.com",
     maintainer="Wiren Board Team",
     maintainer_email="info@wirenboard.com",
-    url="https://github.com/wirenboard/wb-alice-client",
+    url="https://github.com/wirenboard/wb-mqtt-alice",
     # Files installed by debian/install file
     # Requirements installed from debian/control file
 )


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* fix urls
* fix lintian warnings (https://lintian.debian.org/tags/maintainer-script-lacks-debhelper-token and https://lintian.debian.org/tags/maintainer-script-calls-systemctl.html)
* adopt PEP440 (https://github.com/wirenboard/codestyle/pull/88)

___________________________________
**Что поменялось для пользователей:**
nothing

___________________________________
**Как проверял/а:**
CI build

