### PR TITLE
Bugfix/int 481 domain name resolution problem

### DIFF
--- a/configure-nginx-proxy.sh
+++ b/configure-nginx-proxy.sh
@@ -277,14 +277,14 @@ server {
     access_log /var/log/nginx/${PACKET_NAME}_access.log;
     error_log /var/log/nginx/${PACKET_NAME}_error.log debug;
 
-    # Explicit DNS resolver to avoid system DNS timeouts
-    # when internet connection is unavailable
-    resolver 77.88.8.8;
-
-    # Use a variable to prevent NGINX from checking DNS on startup
-    set \$alice_host "${server_host}";
-    
     location / {
+        # Use external DNS to be independent of system settings
+        # and prevent problems when there is no internet connection
+        resolver 77.88.8.8;
+
+        # Use a variable to prevent NGINX from checking DNS on startup
+        set \$alice_host "${server_host}";
+        
         # Required settings - basic proxy configuration
         proxy_pass https://\$alice_host:${server_port};
         proxy_ssl_name \$alice_host;
@@ -302,11 +302,6 @@ server {
         proxy_ssl_protocols TLSv1.3;
         proxy_ssl_verify on;
         proxy_ssl_session_reuse off;
-
-        # Timeouts and error handling
-        proxy_connect_timeout 3s;
-        proxy_read_timeout 10s;
-        proxy_next_upstream error timeout invalid_header;
     }
 }
 EOF

--- a/configure-nginx-proxy.sh
+++ b/configure-nginx-proxy.sh
@@ -279,7 +279,7 @@ server {
 
     # Explicit DNS resolver to avoid system DNS timeouts
     # when internet connection is unavailable
-    resolver 127.0.0.53 valid=2s;
+    resolver 77.88.8.8 valid=30s;
 
     # Use a variable to prevent NGINX from checking DNS on startup
     set \$alice_host "${server_host}";

--- a/configure-nginx-proxy.sh
+++ b/configure-nginx-proxy.sh
@@ -282,12 +282,12 @@ server {
     resolver 127.0.0.53 valid=2s;
 
     # Use a variable to prevent NGINX from checking DNS on startup
-    set $alice_host "${server_host}";
+    set \$alice_host "${server_host}";
     
     location / {
         # Required settings - basic proxy configuration
-        proxy_pass https://$alice_host:${server_port};
-        proxy_ssl_name $alice_host;
+        proxy_pass https://\$alice_host:${server_port};
+        proxy_ssl_name \$alice_host;
         proxy_ssl_certificate ${cert_path};
         proxy_ssl_certificate_key engine:ateccx08:${key_id};
         proxy_ssl_server_name on;

--- a/configure-nginx-proxy.sh
+++ b/configure-nginx-proxy.sh
@@ -282,12 +282,12 @@ server {
     resolver 127.0.0.53 valid=2s;
 
     # Use a variable to prevent NGINX from checking DNS on startup
-    set \$alice_host "${server_host}";
+    set $alice_host "${server_host}";
     
     location / {
         # Required settings - basic proxy configuration
-        proxy_pass https://\$alice_host:${server_port};
-        proxy_ssl_name \$alice_host;
+        proxy_pass https://$alice_host:${server_port};
+        proxy_ssl_name $alice_host;
         proxy_ssl_certificate ${cert_path};
         proxy_ssl_certificate_key engine:ateccx08:${key_id};
         proxy_ssl_server_name on;

--- a/configure-nginx-proxy.sh
+++ b/configure-nginx-proxy.sh
@@ -279,7 +279,7 @@ server {
 
     # Explicit DNS resolver to avoid system DNS timeouts
     # when internet connection is unavailable
-    resolver 77.88.8.8 valid=30s;
+    resolver 77.88.8.8;
 
     # Use a variable to prevent NGINX from checking DNS on startup
     set \$alice_host "${server_host}";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.3.5) stable; urgency=medium
+
+  * Fix error when restarting nginx
+
+ -- Mikhail Burchu <mikhail.burchu@wirenboard.com>  Tue, 19 Aug 2025 15:00:00 +0300
+
 wb-mqtt-alice (0.3.4) stable; urgency=medium
 
   * Fix client-does-not-restart


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
1. Добавил в настройку для nginx работу через переменную, а не прямое указание адреса, чтобы при старте nginx не проверял DNS при старте.
2.  Добавил также резолвер, т.к. без него через переменную не получится работать.
___________________________________
**Что поменялось для пользователей:**
Исправлен баг, при котором при отсутствии интернета и перезагрузке nginx перестает работать веб-интерфейс контроллера.

___________________________________
**Как проверял/а:**
Проверял на локальном контроллере WB7 и WB8

