### PR TITLE
refactor: decrease client log level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.3.6) stable; urgency=medium
+
+  * Decrease client log level
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Mon, 25 Aug 2025 18:00:00 +0300
+
 wb-mqtt-alice (0.3.5) stable; urgency=medium
 
   * Fix error when restarting nginx

--- a/wb-mqtt-alice-client.py
+++ b/wb-mqtt-alice-client.py
@@ -29,6 +29,9 @@ from device_registry import DeviceRegistry
 from yandex_handlers import send_to_yandex_state, set_emit_callback
 
 logging.basicConfig(
+    # For enable full debug
+    # - set level=logging.DEBUG,
+    # - enable log bellow in 'socketio.AsyncClient()'
     level=logging.INFO,
     format='%(levelname)s: %(message)s',
     force=True)
@@ -543,8 +546,8 @@ async def main() -> None:
         return
 
     ctx.sio = socketio.AsyncClient(
-        logger=True,
-        engineio_logger=True,
+        # logger=True,
+        # engineio_logger=True,
         reconnection=True,  # auto-reconnect ON
         reconnection_attempts=0,  # 0 = infinite retries
         reconnection_delay=2,  # first delay 2 s

--- a/wb-mqtt-alice-client.py
+++ b/wb-mqtt-alice-client.py
@@ -29,9 +29,6 @@ from device_registry import DeviceRegistry
 from yandex_handlers import send_to_yandex_state, set_emit_callback
 
 logging.basicConfig(
-    # For enable full debug
-    # - set level=logging.DEBUG,
-    # - enable log bellow in 'socketio.AsyncClient()'
     level=logging.INFO,
     format='%(levelname)s: %(message)s',
     force=True)
@@ -545,9 +542,10 @@ async def main() -> None:
         logger.error(f"MQTT connect failed: {e}")
         return
 
+    is_debug_log_enabled = logger.getEffectiveLevel() == logging.DEBUG
     ctx.sio = socketio.AsyncClient(
-        # logger=True,
-        # engineio_logger=True,
+        logger=is_debug_log_enabled,
+        engineio_logger=is_debug_log_enabled,
         reconnection=True,  # auto-reconnect ON
         reconnection_attempts=0,  # 0 = infinite retries
         reconnection_delay=2,  # first delay 2 s


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Уменьшено колличество логов выводимое по дефолту в лог
- Часть сообщений из инфо переделал в дебаг, тк они не так часто нужны - оставил только логи связанные с соединением и тд
- Перевел уровень логирования питон сервиса в инфо (был дебаг)
- Отключил логирование у SocketIO
___________________________________
**Что поменялось для пользователей:**

В логе теперь меньше информации - особенно заметно у людей которые подвязали датчики температуры к Яндекс умному дому, тк там очень частые обращения из за частого изменения показания датчиков
___________________________________
**Как проверял/а:**

Установил на контроллер, запустил и посмотрел что логи действительно стали сильно меньше
