### PR TITLE
feat: controller unlink frontend part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@
 .idea
 requirements.txt
 pyproject.toml
+__pycache__/constants.cpython-312.pyc
+__pycache__/fetch_url.cpython-312.pyc
+__pycache__/models.cpython-312.pyc
+__pycache__/wb-mqtt-alice-config.cpython-312.pyc

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.4.6) stable; urgency=medium
+
+  * Add feature unlink controller from homeui
+
+ -- Victor Fedorov <victor.fedorov@wirenboard.com>  Mon, 13 Oct 2025 09:00:00 +0300
+
 wb-mqtt-alice (0.4.5) stable; urgency=medium
 
   * Fix processing incomming yandex messages

--- a/wb-mqtt-alice-config.py
+++ b/wb-mqtt-alice-config.py
@@ -601,6 +601,20 @@ async def change_device_room(request: Request, device_id: str, device_data: Room
     return response
 
 
+@app.delete("/integrations/alice/controller", status_code=HTTPStatus.OK)
+async def unlink_controller(request: Request):
+    """Unlink controller"""
+    language = get_language(request)
+    try:
+        fetch_url(
+            url=f"https://{server_address}/request-unlink",
+        )
+    except Exception as e:
+        logger.error("Failed to fetch unregistration URL: %r", e)
+
+    return {"message": get_translation("controller_inlinked", language)}
+
+
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception):
     """


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Чтобы отвязать контроллер надо переходить на страницу с аккаунтом яндекса, что не всегда удобно, например при потере доступа к аккаунту. Необходимо добавить возможность отвязать контроллер из нашего homeui

___________________________________
**Что поменялось для пользователей:**
Появилась новая ссылка для отвязки контроллера

___________________________________
**Как проверял/а:**
На dev сервере

