### PR TITLE
feat: set minimum version of HomeUI INT-823

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.9.1) stable; urgency=medium
+
+  * Set the minimum allowed version of homeui 
+
+ -- Victor Fedorov <victor.fedorov@wirenboard.com>  Wed, 25 Feb 2026 10:39:30 +0300
+
 wb-mqtt-alice (0.9.0) stable; urgency=medium
 
   * Add 4 py packages from project files

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.163.0~~),
+         wb-mqtt-homeui (>= 2.173.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В версии homeui 2.173.0 внедрили новый механизм отображения меню.
В клиенте Алисы мы его заложили в версии 0.8.3.

Теперь надо в клиенте прописать зависимость от homeui 2.173.0 и выше.

___________________________________
**Что поменялось для пользователей:**
Ничего не поменялось.

___________________________________
**Как проверял/а:**


