### PR TITLE
fix: validate room name on renaming INT-848

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.9.2) stable; urgency=medium
+
+  * Add room name validation on update
+
+ -- Victor Fedorov <victor.fedorov@wirenboard.com>  Mon, 02 Mar 2026 15:33:59 +0300
+
 wb-mqtt-alice (0.9.1) stable; urgency=medium
 
   * Set the minimum allowed version of homeui 

--- a/wb/mqtt_alice/config/main.py
+++ b/wb/mqtt_alice/config/main.py
@@ -629,10 +629,12 @@ async def update_room(request: Request, room_id: str, room_data: Room):
     config = load_config()
     # Validate room exists
     validate_room_exists(room_id, config, language)
+    # Validate room name
+    validate_room_name(room_data.name, language)
     # Exclude current room
     other_rooms = {k: v for k, v in config.rooms.items() if k != room_id}
     # Validate room name is unique
-    validate_room_name_unique(room_data.name, config.rooms, language)
+    validate_room_name_unique(room_data.name, other_rooms, language)
     # Update room
     response = room_data.put_response()
     config.rooms[room_id] = response


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Можно создать комнату на русском языке, а потом переименовать ее в латиницу - это потом поломает яндекс алису.

___________________________________
**Что поменялось для пользователей:**
Теперь нельзя переименовывать комнаты не по правилам, добавлен валидатор для этого случая.
<img height="250" alt="image" src="https://github.com/user-attachments/assets/80956bb1-3c36-422a-8cce-cdd04df81ba7" />

___________________________________
**Как проверял/а:**
на локальном контроллере

