### PR TITLE
feat: add batching for notifications INT-652

### DIFF
--- a/configs/wb-mqtt-alice-event-rates.json
+++ b/configs/wb-mqtt-alice-event-rates.json
@@ -1,34 +1,34 @@
 {
   "devices.capabilities.default": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.properties.default": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.on_off": {
-    "rate_timer": 0.75,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.color_setting": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.range": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.mode": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.toggle": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.capabilities.video_stream": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   },
   "devices.properties.float": {
@@ -36,7 +36,7 @@
     "rate_rule": "last_value"
   },
   "devices.properties.event": {
-    "rate_timer": 1,
+    "rate_timer": 0.9,
     "rate_rule": "last_value"
   }
 }

--- a/configs/wb-mqtt-alice-event-rates.json
+++ b/configs/wb-mqtt-alice-event-rates.json
@@ -36,7 +36,7 @@
     "rate_rule": "last_value"
   },
   "devices.properties.event": {
-    "rate_timer": 0.9,
+    "rate_timer": 0.01,
     "rate_rule": "last_value"
   }
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,10 +2,11 @@ wb-mqtt-alice (0.9.3) stable; urgency=medium
 
   * Add batching for device state notifications to Yandex Smart Home:
     merge multiple MQTT updates into a single Socket.IO emit
-    per BATCH_INTERVAL (default 1s), event properties flush immediately
+    per BATCH_WINDOW_NORMAL, time-sensitive types
+    (events) use BATCH_WINDOW_FAST
   * Skip event properties with None value (e.g. button release)
 
- -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Tue, 03 Mar 2026 19:00:00 +0300
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Fri, 06 Mar 2026 16:00:00 +0300
 
 wb-mqtt-alice (0.9.2) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-mqtt-alice (0.9.3) stable; urgency=medium
+
+  * Add batching for device state notifications to Yandex Smart Home:
+    merge multiple MQTT updates into a single Socket.IO emit
+    per BATCH_INTERVAL (default 1s), event properties flush immediately
+  * Skip event properties with None value (e.g. button release)
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Tue, 03 Mar 2026 19:00:00 +0300
+
 wb-mqtt-alice (0.9.2) stable; urgency=medium
 
   * Add room name validation on update

--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,6 @@
 # - - Python packets - -
 # NOTE: Installed by setup.py
-#       Standart files path "/usr/lib/python3/dist-packages/wb/mqtt-alice/..."
+#       Standart files path "/usr/lib/python3/dist-packages/wb/mqtt_alice/..."
 
 # - - Scripts - -
 

--- a/wb/mqtt_alice/client/device_registry.py
+++ b/wb/mqtt_alice/client/device_registry.py
@@ -233,7 +233,7 @@ class DeviceRegistry:
         self,
         cfg_path: str,
         *,
-        send_to_yandex: Callable[[str, str, Optional[str], Any], None],
+        send_to_yandex: Callable[[str, str, Optional[str], Any], Optional[Dict[str, Any]]],
         publish_to_mqtt: Callable[[str, str], Awaitable[None]],
         cfg_events_path: Optional[str] = CONFIG_EVENTS_RATE_PATH,
     ) -> None:
@@ -642,13 +642,18 @@ class DeviceRegistry:
             return extract_event_value(value)
         return raw
 
-    def forward_mqtt_to_yandex(self, topic: str, raw: str) -> None:
+    def convert_mqtt_to_yandex_block(self, topic: str, raw: str) -> Optional[Dict[str, Any]]:
         """
-        Forwards MQTT message to Yandex Smart Home
+        Convert MQTT message to Yandex Smart Home device state block
 
         Args:
-            topic: MQTT topic in full format (/devices/device/controls/control)
-            raw: Raw payload string from MQTT message
+            - topic: MQTT topic in full format (/devices/device/controls/control)
+            - raw: Raw payload string from MQTT message
+        
+        Returns:
+            - Device state block dict
+              {"id": ..., "status": ..., "capabilities"/"properties": [...]}
+            - or None if topic unknown, conversion failed, or event value is None
         """
         if topic not in self.topic2info:
             return None
@@ -670,11 +675,16 @@ class DeviceRegistry:
                     value=raw,
                     event_single_topic=event_single_topic
                 )
+                if value is None:
+                    # Event not triggered (e.g. button release "0") — skip silently
+                    logger.debug("Event value is None for topic %r, skipping", topic)
+                    return None
             else:
                 value = self._convert_cap_to_yandex(raw, cap_type, instance, blk.get("parameters"))
-            self._send_to_yandex(device_id, cap_type, instance, value)
+            return self._send_to_yandex(device_id, cap_type, instance, value)
         except (ValueError, TypeError) as e:
             logger.warning("Failed to convert MQTT→Yandex for topic %r: %r", topic, e)
+            return None
 
     def _convert_cap_to_mqtt(
         self, 

--- a/wb/mqtt_alice/client/main.py
+++ b/wb/mqtt_alice/client/main.py
@@ -34,7 +34,7 @@ import engineio
 from wb.mqtt_alice.common.constants import SERVER_CONFIG_PATH, DEVICE_PATH, SHORT_SN_PATH, CLIENT_CONFIG_PATH
 from .device_registry import DeviceRegistry
 from .wb_alice_device_state_sender import AliceDeviceStateSender
-from .yandex_handlers import send_to_yandex_state, set_emit_callback
+from .yandex_handlers import convert_to_yandex_block, set_emit_callback
 from .sio_alice_handlers import SioAliceHandlers
 from .sio_connection_manager import SioConnectionManager
 
@@ -654,7 +654,7 @@ async def main() -> int:
     try:
         ctx.registry = DeviceRegistry(
             cfg_path=DEVICE_PATH,
-            send_to_yandex=send_to_yandex_state,
+            send_to_yandex=convert_to_yandex_block,
             publish_to_mqtt=publish_to_mqtt,
         )
         logger.debug("Registry created with %r devices", len(ctx.registry.devices))

--- a/wb/mqtt_alice/client/main.py
+++ b/wb/mqtt_alice/client/main.py
@@ -130,7 +130,7 @@ def _emit_async(event: str, data: Dict[str, Any]) -> None:
         logger.debug("            Payload: %r", json.dumps(data))
         return None
 
-    logger.debug("Attempting to emit %r with payload: %r", event, data)
+    logger.debug("Attempting to emit %r with payload: %r", event, json.dumps(data))
     sio_client = ctx.sio_manager.client
     
     try:

--- a/wb/mqtt_alice/client/main.py
+++ b/wb/mqtt_alice/client/main.py
@@ -627,7 +627,7 @@ async def main() -> int:
 
     # Apply log level from client config
     log_level_name = str(client_cfg.get("log_level", "INFO")).upper()
-    logger.setLevel(log_level_name)
+    logging.getLogger().setLevel(log_level_name) # Change root logger
 
     if not client_cfg.get("client_enabled", False):
         logger.info("Alice integration is DISABLED in configuration")

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -321,7 +321,7 @@ class AliceDeviceStateSender:
                 async with self._topic_buffers_lock:
                     for topic, messages in self.topic_buffers.items():
                         if not messages:
-                            logger.debug("not message info for topic=%s", topic)
+                            # logger.debug("not message info for topic=%s", topic)
                             continue
                         last_send_time = self.last_send_times.get(topic, 0)
                         rate = messages[-1]["origin_rate"].time_rate

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -24,9 +24,9 @@ MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
 BATCH_WINDOW_NORMAL = float(getenv("BATCH_WINDOW_NORMAL", "1.0"))
 BATCH_WINDOW_FAST = float(getenv("BATCH_WINDOW_FAST", "0.05"))
 
-# Types that trigger immediate batch flush (bypass BATCH_INTERVAL)
+# Types that use fast delivery window (BATCH_WINDOW_FAST instead of BATCH_WINDOW_NORMAL)
 # When a block of this type passes Stage 1 rate limiter,
-# accumulated batch is flushed immediately instead of waiting
+# the batch flush timer is set/shortened to BATCH_WINDOW_FAST
 IMMEDIATE_FLUSH_TYPES: frozenset = frozenset({
     "devices.properties.event",  # Events MUST be send fast
     # Can add new types on this place
@@ -158,7 +158,8 @@ class AliceDeviceStateSender:
 
     Stage 2 — Batch accumulator:
       Converted Yandex blocks from Stage 1 accumulate in BatchDeviceStore
-      Flushed every BATCH_INTERVAL seconds or on event property arrival
+      Flushed after BATCH_WINDOW_NORMAL (1s) or BATCH_WINDOW_FAST (50ms)
+      for time-sensitive types. Timer is managed by call_later.
       Blocks are deduplicated by (device_id, type, instance)
     """
 

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -22,7 +22,7 @@ MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
 # FAST: shortened window for time-sensitive types (events, etc.)
 #       50ms is enough to batch simultaneous events, but fast enough for UX
 BATCH_WINDOW_NORMAL = float(getenv("BATCH_WINDOW_NORMAL", "1.0"))
-BATCH_WINDOW_FAST = float(getenv("BATCH_WINDOW_FAST", "0.05"))
+BATCH_WINDOW_FAST = float(getenv("BATCH_WINDOW_FAST", "0.1"))
 
 # Types that use fast delivery window (BATCH_WINDOW_FAST instead of BATCH_WINDOW_NORMAL)
 # When a block of this type passes Stage 1 rate limiter,
@@ -158,7 +158,7 @@ class AliceDeviceStateSender:
 
     Stage 2 — Batch accumulator:
       Converted Yandex blocks from Stage 1 accumulate in BatchDeviceStore
-      Flushed after BATCH_WINDOW_NORMAL (1s) or BATCH_WINDOW_FAST (50ms)
+      Flushed after BATCH_WINDOW_NORMAL or BATCH_WINDOW_FAST
       for time-sensitive types. Timer is managed by call_later.
       Blocks are deduplicated by (device_id, type, instance)
     """

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -48,6 +48,27 @@ class AliceDeviceStateSender:
         self.device_registry = device_registry
 
         # Batch accumulator for converted Yandex blocks
+        # Struct example:
+        # batch_buffer = [
+        #     # temperature
+        #     {
+        #         "id": "60ba5cbd-260128210608-79782ee3-c3a2-4143-9caf-ca83c523d7d7",
+        #         "status": "online",
+        #         "properties": [{
+        #             "type": "devices.properties.float",
+        #             "state": {"instance": "temperature", "value": 11.3}
+        #         }]
+        #     },
+        #     # First on_off
+        #     {
+        #         "id": "60ba5cbd-260128210608-79782ee3-c3a2-4143-9caf-ca83c523d7d7",
+        #         "status": "online",
+        #         "capabilities": [{
+        #             "type": "devices.capabilities.on_off",
+        #             "state": {"instance": "on", "value": True}
+        #         }]
+        #     },
+        # ]
         self.batch_buffer: List[Dict[str, Any]] = []
         self.flush_event = asyncio.Event()
         self._task: Optional[asyncio.Task] = None
@@ -254,20 +275,28 @@ def merge_device_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             merged[device_id] = {
                 "id": device_id,
                 "status": block.get("status", "online"),
-                "capabilities": [],
-                "properties": [],
+                "capabilities": {},  # Keyed by (type, instance)
+                "properties": {},    # Keyed by (type, instance)
             }
-        if "capabilities" in block:
-            merged[device_id]["capabilities"].extend(block["capabilities"])
-        if "properties" in block:
-            merged[device_id]["properties"].extend(block["properties"])
+        for cap in block.get("capabilities", []):
+            key = (cap["type"], cap["state"]["instance"])
+            merged[device_id]["capabilities"][key] = cap
+        for prop in block.get("properties", []):
+            key = (prop["type"], prop["state"]["instance"])
+            merged[device_id]["properties"][key] = prop
 
     # Remove empty lists before sending
     result: List[Dict[str, Any]] = []
     for device in merged.values():
-        if not device["capabilities"]:
+        caps = list(device["capabilities"].values())
+        props = list(device["properties"].values())
+        if caps:
+            device["capabilities"] = caps
+        else:
             del device["capabilities"]
-        if not device["properties"]:
+        if props:
+            device["properties"] = props
+        else:
             del device["properties"]
         result.append(device)
 

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -9,12 +9,6 @@ from typing import Any, Dict, List, Optional
 from .device_registry import DeviceRegistry
 from .yandex_handlers import emit_batched_states
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(funcName)s:%(lineno)d - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-logging.captureWarnings(True)
 logger = logging.getLogger(__name__)
 
 MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
@@ -53,7 +47,7 @@ class AliceDeviceStateSender:
         Start the background send loop
         """
         logger.info(
-            "Starting alice device state sender (batch_interval=%.1fs)", BATCH_INTERVAL
+            "Starting alice device state sender (BATCH_INTERVAL=%.1fs)", BATCH_INTERVAL
         )
         self.running = True
         asyncio.create_task(self.send_to_yandex_loop())
@@ -124,7 +118,7 @@ class AliceDeviceStateSender:
                         if current_time - last_send_time <= rate:
                             continue  # Rate limit not passed yet
 
-                        # Rate limit passed → aggregate and convert
+                        # Rate limit passed - do aggregate and convert
                         aggregated = self.modify_messages_by_rule(
                             rule=messages[-1]["origin_rate"].rule,
                             messages=messages,
@@ -145,16 +139,21 @@ class AliceDeviceStateSender:
 
                 # --- Stage 2: Batch flush ---
                 batch_age = current_time - last_batch_time
+                flush_triggered = self.flush_event.is_set()
                 should_flush = (
                     self.batch_buffer
-                    and (batch_age >= BATCH_INTERVAL or self.flush_event.is_set())
+                    and (batch_age >= BATCH_INTERVAL or flush_triggered)
                 )
                 if should_flush:
                     self.flush_event.clear()
                     merged = merge_device_blocks(self.batch_buffer)
                     logger.debug(
-                        "Batch flush: %d block(s) → %d device(s)",
-                        len(self.batch_buffer), len(merged),
+                        "Batch flush: age=%.2fs, interval=%.1fs, event_trigger=%s, %d block(s) in %d device(s)",
+                        batch_age,
+                        BATCH_INTERVAL,
+                        flush_triggered,
+                        len(self.batch_buffer),
+                        len(merged),
                     )
                     emit_batched_states(merged)
                     self.batch_buffer.clear()

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional
 from .device_registry import DeviceRegistry
 from .yandex_handlers import emit_batched_states
 
+PROP_EVENT_TYPE = "devices.properties.event"
+
 logger = logging.getLogger(__name__)
 
 MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
@@ -31,7 +33,7 @@ class AliceDeviceStateSender:
     """
 
     def __init__(self, device_registry: DeviceRegistry):
-        self.buffers = defaultdict(list)
+        self.topic_buffers = defaultdict(list)
         self.last_send_times = {}  # dict of last times by topic
         self.lock = asyncio.Lock()
         self.running = False
@@ -82,22 +84,26 @@ class AliceDeviceStateSender:
                 "origin_rate": event_rate,
             }
             logger.debug("add message: message %s", message)
-            self.buffers[topic_str].append(message)
+            self.topic_buffers[topic_str].append(message)
             # Limit buffer size (sliding window)
-            if len(self.buffers[topic_str]) > MAX_BUFFER_SIZE:
-                self.buffers[topic_str] = self.buffers[topic_str][-MAX_BUFFER_SIZE:]
+            if len(self.topic_buffers[topic_str]) > MAX_BUFFER_SIZE:
+                self.topic_buffers[topic_str] = self.topic_buffers[topic_str][-MAX_BUFFER_SIZE:]
 
-            # Event property trigger immediate batch flush
-            blk = self.device_registry.devices[device_id][cap_prop][idx]
-            if blk.get("type", "").lower() == "devices.properties.event":
-                logger.debug("Event on %r, triggering batch flush", topic_str)
-                self.flush_event.set()
+
+    def _is_event_topic(self, topic: str) -> bool:
+        """
+        Check if topic is configured as event property
+        """
+        device_id, cap_prop, idx, _ = self.device_registry.topic2info.get(topic)
+        blk_type = self.device_registry.devices[device_id][cap_prop][idx].get("type", "")
+        return blk_type.lower() == PROP_EVENT_TYPE
 
 
     async def send_to_yandex_loop(self):
         """
-        Send message to yandex device
-        This is background loop: stage 1 (rate limiter) + stage 2 (batch flush)
+        Background loop for send batched messages to yandex device in 2 stages:
+          1. Rate limiter
+          2. Batch flush
         """
         last_batch_time = time.time()
 
@@ -107,7 +113,7 @@ class AliceDeviceStateSender:
                 # --- Stage 1: Per-topic rate limiter ---
                 # Only pass topics whose time_rate elapsed, result goes to batch_buffer
                 async with self.lock:
-                    for topic, messages in self.buffers.items():
+                    for topic, messages in self.topic_buffers.items():
                         if not messages:
                             logger.debug("not message info for topic=%s", topic)
                             continue
@@ -123,18 +129,23 @@ class AliceDeviceStateSender:
                             rule=messages[-1]["origin_rate"].rule,
                             messages=messages,
                         )
-                        raw = str(aggregated["payload"])
+                        aggregated_payload = str(aggregated["payload"])
                         # send message to Yandex
                         if os.getenv("__DEBUG__"):
-                            logger.info("[DEBUG] rate-passed: topic=%s, raw=%s", topic, raw)
+                            logger.info("[DEBUG] rate-passed: topic=%s, aggregated_payload=%s", topic, aggregated_payload)
                         else:
                             block = self.device_registry.convert_mqtt_to_yandex_block(
-                                topic=topic, raw=raw
+                                topic=topic, raw=aggregated_payload
                             )
                             if block is not None:
                                 self.batch_buffer.append(block)
 
-                        self.buffers[topic].clear()
+                                # Event property trigger immediate batch flush
+                                if self._is_event_topic(topic):
+                                    logger.debug("Event on %r, triggering batch flush", topic)
+                                    self.flush_event.set()
+
+                        self.topic_buffers[topic].clear()
                         self.last_send_times[topic] = current_time
 
                 # --- Stage 2: Batch flush ---
@@ -172,11 +183,9 @@ class AliceDeviceStateSender:
 
         logger.info("send loop finished")
 
-    def get_device_info_by_topic(self, topic):
-        return self.device_registry.topic2info.get(topic)
 
     @staticmethod
-    def modify_messages_by_rule(rule: str, messages: List[dict]):
+    def modify_messages_by_rule(rule: str, messages: List[dict]) -> dict:
         """
         Apply aggregation rule to buffered messages for one topic
         Returns single message dict with aggregated payload

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -16,7 +16,7 @@ PROP_EVENT_TYPE = "devices.properties.event"
 # accumulated batch is flushed immediately instead of waiting
 IMMEDIATE_FLUSH_TYPES: frozenset = frozenset({
     "devices.properties.event",  # Events MUST be send fast
-    "devices.capabilities.on_off",  # on_off have minimum latency in event-rates
+    # Can add new types on this place
 })
 
 logger = logging.getLogger(__name__)

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -232,6 +232,21 @@ class AliceDeviceStateSender:
             return False
         return blk_type in IMMEDIATE_FLUSH_TYPES
 
+    def _try_flush(self) -> bool:
+        """
+        Stage 2: flush batch store if not empty
+        Extracted as method to allow calling from both
+        polling loop (current) and call_later (future variant C)
+
+        Returns:
+            True if data was flushed, False if store was empty
+        """
+        if self._batch_store.is_empty:
+            return False
+        merged = self._batch_store.drain()
+        logger.debug("Batch flush: done - flushed %d device(s)", len(merged))
+        emit_batched_states(merged)
+        return True
 
     async def send_to_yandex_loop(self):
         """
@@ -293,38 +308,18 @@ class AliceDeviceStateSender:
                 # --- Stage 2: Batch flush ---
                 batch_age = current_time - last_batch_time
                 flush_triggered = self.flush_event.is_set()
-                should_flush = (
-                    not self._batch_store.is_empty
-                    and (batch_age >= BATCH_INTERVAL or flush_triggered)
-                )
-                if should_flush:
+                if batch_age >= BATCH_INTERVAL or flush_triggered:
                     self.flush_event.clear()
-                    logger.debug(
-                        "Now will be flushed batch: age=%.2fs, interval=%.1fs, event_trigger=%s, %d device(s)",
-                        batch_age,
-                        BATCH_INTERVAL,
-                        flush_triggered,
-                        len(self._batch_store),
-                    )
-                    merged = self._batch_store.drain()
-                    logger.debug(
-                        "Batch flush: done - flushed %d device(s)",
-                        len(merged),
-                    )
-                    emit_batched_states(merged)
-                    last_batch_time = current_time
+                    if self._try_flush():
+                        last_batch_time = current_time
 
             except Exception as e:
                 logger.error("Error in send loop: %s", e, exc_info=True)
             await asyncio.sleep(0.1)
 
         # Final flush on shutdown
-        if not self._batch_store.is_empty:
-            merged = self._batch_store.drain()
-            emit_batched_states(merged)
-            logger.debug("Final flush on shutdown: %d device(s)", len(merged))
-
-        logger.info("send loop finished")
+        self._try_flush()
+        logger.info("Send loop finished")
 
 
     @staticmethod

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import time
+import threading
 from collections import defaultdict
 from os import getenv
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,10 @@ class BatchDeviceStore:
     """
     Deduplicated storage for device state blocks awaiting batch flush
 
+    Thread safety:
+        All public methods are protected by threading.Lock
+        Safe to call from any context (sync, async, threaded)
+    
     Blocks are added and merged by device_id, capabilities and properties
     are deduplicated by (type, instance) - only latest value is kept
 
@@ -71,44 +76,60 @@ class BatchDeviceStore:
 
     def __init__(self) -> None:
         self._devices: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
 
     def __len__(self) -> int:
         """
         Number of devices in storage
         """
-        return len(self._devices)
+        with self._lock:
+            return len(self._devices)
 
     @property
     def is_empty(self) -> bool:
-        return not self._devices
+        with self._lock:
+            return not self._devices
 
     def merge_block(self, block: Dict[str, Any]) -> None:
         """
         Merge block into storage with deduplication by (device_id, type, instance)
         If same (type, instance) already exists for this device, value is overwritten
         """
-        device_id = block["id"]
-        if device_id not in self._devices:
-            self._devices[device_id] = {
-                "status": block.get("status", "online"),
-                "capabilities": {},
-                "properties": {},
-            }
-        device = self._devices[device_id]
-        for cap in block.get("capabilities", []):
-            key = (cap["type"], cap["state"]["instance"])
-            device["capabilities"][key] = cap
-        for prop in block.get("properties", []):
-            key = (prop["type"], prop["state"]["instance"])
-            device["properties"][key] = prop
+        with self._lock:
+            device_id = block["id"]
+            if device_id not in self._devices:
+                self._devices[device_id] = {
+                    "status": block.get("status", "online"),
+                    "capabilities": {},
+                    "properties": {},
+                }
+            device = self._devices[device_id]
+            for cap in block.get("capabilities", []):
+                key = (cap["type"], cap["state"]["instance"])
+                device["capabilities"][key] = cap
+            for prop in block.get("properties", []):
+                key = (prop["type"], prop["state"]["instance"])
+                device["properties"][key] = prop
 
     def drain(self) -> List[Dict[str, Any]]:
         """
         Return all accumulated devices as list and clear storage
+
         After this call, is_empty is True
+        Uses reference swap: new writes go to a fresh dict,
+        result is built from the old one — safe if merge_block()
+        is called during _build_result() processing
         """
+        with self._lock:
+            # swap: merge_block() will now writes to new dict
+            snapshot = self._devices
+            self._devices = {}
+        return self._build_result(snapshot)
+
+    @staticmethod
+    def _build_result(devices: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
         result: List[Dict[str, Any]] = []
-        for device_id, device in self._devices.items():
+        for device_id, device in devices.items():
             entry: Dict[str, Any] = {"id": device_id, "status": device["status"]}
             caps = list(device["capabilities"].values())
             props = list(device["properties"].values())
@@ -117,7 +138,6 @@ class BatchDeviceStore:
             if props:
                 entry["properties"] = props
             result.append(entry)
-        self._devices.clear()
         return result
 
 class AliceDeviceStateSender:
@@ -138,7 +158,7 @@ class AliceDeviceStateSender:
     def __init__(self, device_registry: DeviceRegistry):
         self.topic_buffers = defaultdict(list)
         self.last_send_times = {}  # dict of last times by topic
-        self.lock = asyncio.Lock()
+        self._topic_buffers_lock = asyncio.Lock()
         self.running = False
         self.device_registry = device_registry
 
@@ -178,7 +198,7 @@ class AliceDeviceStateSender:
         """
         logger.debug("add message %s %s", topic_str, payload_str)
 
-        async with self.lock:
+        async with self._topic_buffers_lock:
             info = self.device_registry.topic2info.get(topic_str)
             if info is None:
                 logger.debug("Unknown topic %r, ignoring", topic_str)
@@ -227,7 +247,7 @@ class AliceDeviceStateSender:
                 # --- Stage 1: Per-topic rate limiter ---
                 # Collect data under lock, convert outside
                 topics_to_convert: List[tuple] = []
-                async with self.lock:
+                async with self._topic_buffers_lock:
                     for topic, messages in self.topic_buffers.items():
                         if not messages:
                             logger.debug("not message info for topic=%s", topic)
@@ -280,7 +300,7 @@ class AliceDeviceStateSender:
                 if should_flush:
                     self.flush_event.clear()
                     logger.debug(
-                        "Now will be flushed batch: age=%.2fs, interval=%.1fs, event_trigger=%s, %d block(s)",
+                        "Now will be flushed batch: age=%.2fs, interval=%.1fs, event_trigger=%s, %d device(s)",
                         batch_age,
                         BATCH_INTERVAL,
                         flush_triggered,

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -5,12 +5,24 @@ import time
 import threading
 from collections import defaultdict
 from os import getenv
+from asyncio import AbstractEventLoop, TimerHandle
 from typing import Any, Dict, List, Optional
 
 from .device_registry import DeviceRegistry
 from .yandex_handlers import emit_batched_states
 
+logger = logging.getLogger(__name__)
+
 PROP_EVENT_TYPE = "devices.properties.event"
+
+MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
+
+# Batch flush windows (seconds)
+# NORMAL: default window for regular state updates (temperature, brightness, etc.)
+# FAST: shortened window for time-sensitive types (events, etc.)
+#       50ms is enough to batch simultaneous events, but fast enough for UX
+BATCH_WINDOW_NORMAL = float(getenv("BATCH_WINDOW_NORMAL", "1.0"))
+BATCH_WINDOW_FAST = float(getenv("BATCH_WINDOW_FAST", "0.05"))
 
 # Types that trigger immediate batch flush (bypass BATCH_INTERVAL)
 # When a block of this type passes Stage 1 rate limiter,
@@ -19,11 +31,6 @@ IMMEDIATE_FLUSH_TYPES: frozenset = frozenset({
     "devices.properties.event",  # Events MUST be send fast
     # Can add new types on this place
 })
-
-logger = logging.getLogger(__name__)
-
-MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
-BATCH_INTERVAL = float(getenv("BATCH_INTERVAL", "1.0"))
 
 class BatchDeviceStore:
     """
@@ -162,8 +169,10 @@ class AliceDeviceStateSender:
         self.running = False
         self.device_registry = device_registry
 
-        self.flush_event = asyncio.Event()
         self._batch_store = BatchDeviceStore()
+        self._flush_handle: Optional[TimerHandle] = None
+        self._current_window: float = 0.0
+        self._loop: Optional[AbstractEventLoop] = None
         self._task: Optional[asyncio.Task] = None
 
 
@@ -172,7 +181,9 @@ class AliceDeviceStateSender:
         Start the background send loop
         """
         logger.info(
-            "Starting alice device state sender (BATCH_INTERVAL=%.1fs)", BATCH_INTERVAL
+            "Starting alice device state sender (normal=%.2fs, fast=%.3fs)",
+            BATCH_WINDOW_NORMAL,
+            BATCH_WINDOW_FAST,
         )
         self.running = True
         self._task = asyncio.create_task(self.send_to_yandex_loop())
@@ -183,7 +194,6 @@ class AliceDeviceStateSender:
         Wakes loop so it can do a final flush before exiting
         """
         self.running = False
-        self.flush_event.set()
         logger.info("Stopping alice device state sender")
         if self._task is not None:
             try:
@@ -232,11 +242,49 @@ class AliceDeviceStateSender:
             return False
         return blk_type in IMMEDIATE_FLUSH_TYPES
 
+    def _schedule_flush(self, time_sensitive: bool = False) -> None:
+        """
+        Schedule or shorten batch flush timer
+
+        Rules:
+          - First block in empty batch: schedule after FAST or NORMAL window
+          - Time-sensitive block during NORMAL window: shorten to FAST
+          - Time-sensitive block during FAST window: do nothing (already fast)
+          - Normal block during any window: do nothing (keep current timer)
+        """
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        window = BATCH_WINDOW_FAST if time_sensitive else BATCH_WINDOW_NORMAL
+
+        if self._flush_handle is None:
+            # No timer yet — schedule new one
+            self._current_window = window
+            self._flush_handle = self._loop.call_later(window, self._do_flush)
+            logger.debug("Flush scheduled in %.3fs (time_sensitive=%s)", window, time_sensitive)
+
+        elif time_sensitive and self._current_window > BATCH_WINDOW_FAST:
+            # Shorten: cancel current timer and reschedule with fast window
+            self._flush_handle.cancel()
+            self._current_window = BATCH_WINDOW_FAST
+            self._flush_handle = self._loop.call_later(BATCH_WINDOW_FAST, self._do_flush)
+            logger.debug("Flush rescheduled to %.3fs (time_sensitive block arrived)", BATCH_WINDOW_FAST)
+
+
+    def _do_flush(self) -> None:
+        """
+        Timer callback: reset timer state and flush.
+        Called by loop.call_later — must be sync.
+        """
+        self._flush_handle = None
+        self._current_window = 0.0
+        self._try_flush()
+
+
     def _try_flush(self) -> bool:
         """
-        Stage 2: flush batch store if not empty
-        Extracted as method to allow calling from both
-        polling loop (current) and call_later (future variant C)
+        Flush batch store if not empty
+        Called from _do_flush (timer) and shutdown
 
         Returns:
             True if data was flushed, False if store was empty
@@ -248,14 +296,21 @@ class AliceDeviceStateSender:
         emit_batched_states(merged)
         return True
 
+    def _cancel_flush_timer(self) -> None:
+        """
+        Cancel scheduled flush if any
+        """
+        if self._flush_handle is not None:
+            self._flush_handle.cancel()
+            self._flush_handle = None
+            self._current_window = 0.0
+
     async def send_to_yandex_loop(self):
         """
         Background loop for send batched messages to yandex device in 2 stages:
-          1. Rate limiter
-          2. Batch flush
+          Stage 1: per-topic rate limiter
+          Stage 2: (batch flush) is handled by _schedule_flush / call_later
         """
-        last_batch_time = time.time()
-
         while self.running:
             try:
                 current_time = time.time()
@@ -297,27 +352,21 @@ class AliceDeviceStateSender:
                         if block is not None:
                             self._batch_store.merge_block(block)
 
-                            # Event property trigger immediate batch flush
-                            if self._needs_immediate_flush(topic):
+                            # Schedule batch flush with appropriate window
+                            time_sensitive = self._needs_immediate_flush(topic)
+                            self._schedule_flush(time_sensitive=time_sensitive)
+                            if time_sensitive:
                                 logger.debug(
-                                    "Triggered immediate batch flush, because got update topic: %r",
+                                    "Triggered fast batch flush, because got update time-sensitive block from topic: %r",
                                     topic
                                 )
-                                self.flush_event.set()
-
-                # --- Stage 2: Batch flush ---
-                batch_age = current_time - last_batch_time
-                flush_triggered = self.flush_event.is_set()
-                if batch_age >= BATCH_INTERVAL or flush_triggered:
-                    self.flush_event.clear()
-                    if self._try_flush():
-                        last_batch_time = current_time
 
             except Exception as e:
                 logger.error("Error in send loop: %s", e, exc_info=True)
             await asyncio.sleep(0.1)
 
-        # Final flush on shutdown
+        # Shutdown: cancel pending timer and flush remaining
+        self._cancel_flush_timer()
         self._try_flush()
         logger.info("Send loop finished")
 

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -11,6 +11,14 @@ from .yandex_handlers import emit_batched_states
 
 PROP_EVENT_TYPE = "devices.properties.event"
 
+# Types that trigger immediate batch flush (bypass BATCH_INTERVAL)
+# When a block of this type passes Stage 1 rate limiter,
+# accumulated batch is flushed immediately instead of waiting
+IMMEDIATE_FLUSH_TYPES: frozenset = frozenset({
+    "devices.properties.event",  # Events MUST be send fast
+    "devices.capabilities.on_off",  # on_off have minimum latency in event-rates
+})
+
 logger = logging.getLogger(__name__)
 
 MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
@@ -42,6 +50,7 @@ class AliceDeviceStateSender:
         # Batch accumulator for converted Yandex blocks
         self.batch_buffer: List[Dict[str, Any]] = []
         self.flush_event = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
 
 
     async def start(self):
@@ -52,7 +61,7 @@ class AliceDeviceStateSender:
             "Starting alice device state sender (BATCH_INTERVAL=%.1fs)", BATCH_INTERVAL
         )
         self.running = True
-        asyncio.create_task(self.send_to_yandex_loop())
+        self._task = asyncio.create_task(self.send_to_yandex_loop())
 
     async def stop(self):
         """
@@ -62,6 +71,11 @@ class AliceDeviceStateSender:
         self.running = False
         self.flush_event.set()
         logger.info("Stopping alice device state sender")
+        if self._task is not None:
+            try:
+                await self._task
+            except Exception:
+                logger.error("Error in send loop task during shutdown", exc_info=True)
 
     async def add_message(self, topic_str: str, payload_str: str):
         """
@@ -90,13 +104,19 @@ class AliceDeviceStateSender:
                 self.topic_buffers[topic_str] = self.topic_buffers[topic_str][-MAX_BUFFER_SIZE:]
 
 
-    def _is_event_topic(self, topic: str) -> bool:
+    def _needs_immediate_flush(self, topic: str) -> bool:
         """
-        Check if topic is configured as event property
+        Check if topic type is in IMMEDIATE_FLUSH_TYPES
         """
-        device_id, cap_prop, idx, _ = self.device_registry.topic2info.get(topic)
-        blk_type = self.device_registry.devices[device_id][cap_prop][idx].get("type", "")
-        return blk_type.lower() == PROP_EVENT_TYPE
+        info = self.device_registry.topic2info.get(topic)
+        if info is None:
+            return False
+        device_id, cap_prop, idx, _ = info
+        try:
+            blk_type = self.device_registry.devices[device_id][cap_prop][idx].get("type", "").lower()
+        except (KeyError, IndexError):
+            return False
+        return blk_type in IMMEDIATE_FLUSH_TYPES
 
 
     async def send_to_yandex_loop(self):
@@ -111,7 +131,8 @@ class AliceDeviceStateSender:
             try:
                 current_time = time.time()
                 # --- Stage 1: Per-topic rate limiter ---
-                # Only pass topics whose time_rate elapsed, result goes to batch_buffer
+                # Collect data under lock, convert outside
+                topics_to_convert: List[tuple] = []
                 async with self.lock:
                     for topic, messages in self.topic_buffers.items():
                         if not messages:
@@ -130,23 +151,30 @@ class AliceDeviceStateSender:
                             messages=messages,
                         )
                         aggregated_payload = str(aggregated["payload"])
-                        # send message to Yandex
-                        if os.getenv("__DEBUG__"):
-                            logger.info("[DEBUG] rate-passed: topic=%s, aggregated_payload=%s", topic, aggregated_payload)
-                        else:
-                            block = self.device_registry.convert_mqtt_to_yandex_block(
-                                topic=topic, raw=aggregated_payload
-                            )
-                            if block is not None:
-                                self.batch_buffer.append(block)
-
-                                # Event property trigger immediate batch flush
-                                if self._is_event_topic(topic):
-                                    logger.debug("Event on %r, triggering batch flush", topic)
-                                    self.flush_event.set()
-
-                        self.topic_buffers[topic].clear()
+                        topics_to_convert.append((topic, aggregated_payload))
+                        messages.clear()
                         self.last_send_times[topic] = current_time
+
+
+                # Only pass topics whose time_rate elapsed, result goes to batch_buffer
+                # If All ok - send message to Yandex
+                for topic, aggregated_payload in topics_to_convert:
+                    if os.getenv("__DEBUG__"):
+                        logger.info("[DEBUG] rate-passed: topic=%s, aggregated_payload=%s", topic, aggregated_payload)
+                    else:
+                        block = self.device_registry.convert_mqtt_to_yandex_block(
+                            topic=topic, raw=aggregated_payload
+                        )
+                        if block is not None:
+                            self.batch_buffer.append(block)
+
+                            # Event property trigger immediate batch flush
+                            if self._needs_immediate_flush(topic):
+                                logger.debug(
+                                    "Triggered immediate batch flush, because got update topic: %r",
+                                    topic
+                                )
+                                self.flush_event.set()
 
                 # --- Stage 2: Batch flush ---
                 batch_age = current_time - last_batch_time

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -4,9 +4,10 @@ import os
 import time
 from collections import defaultdict
 from os import getenv
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from .device_registry import DeviceRegistry
+from .yandex_handlers import emit_batched_states
 
 logging.basicConfig(
     level=logging.INFO,
@@ -17,11 +18,22 @@ logging.captureWarnings(True)
 logger = logging.getLogger(__name__)
 
 MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
+BATCH_INTERVAL = float(getenv("BATCH_INTERVAL", "1.0"))
 
 
 class AliceDeviceStateSender:
     """
-    Class to send device states with time-rate
+    Two-stage sender for device state updates to Yandex Smart Home
+
+    Stage 1 — Per-topic rate limiter (existing logic):
+      Each topic has its own time_rate. Messages arriving faster than
+      time_rate are buffered and aggregated (last_value / average_value)
+      Only when time_rate has elapsed does the topic "pass" to stage 2
+
+    Stage 2 — Batch accumulator:
+      Converted Yandex blocks from stage 1 accumulate in batch_buffer
+      Flushed every BATCH_INTERVAL seconds or immediately when
+      an event property arrives. Blocks are merged by device_id
     """
 
     def __init__(self, device_registry: DeviceRegistry):
@@ -31,31 +43,44 @@ class AliceDeviceStateSender:
         self.running = False
         self.device_registry = device_registry
 
+        # Batch accumulator for converted Yandex blocks
+        self.batch_buffer: List[Dict[str, Any]] = []
+        self.flush_event = asyncio.Event()
+
+
     async def start(self):
         """
-        start task to time-rated send states
+        Start the background send loop
         """
-        logger.info("start alice device state sender")
+        logger.info(
+            "Starting alice device state sender (batch_interval=%.1fs)", BATCH_INTERVAL
+        )
         self.running = True
         asyncio.create_task(self.send_to_yandex_loop())
 
     async def stop(self):
         """
-        stop task
+        Stop the background send loop
+        Wakes loop so it can do a final flush before exiting
         """
         self.running = False
-        logger.info("stop alice device state sender")
+        self.flush_event.set()
+        logger.info("Stopping alice device state sender")
 
     async def add_message(self, topic_str: str, payload_str: str):
         """
-        Add message to buffer
+        Add MQTT message to per-topic buffer
+        If message is an event property, triggers immediate batch flush
         """
         logger.debug("add message %s %s", topic_str, payload_str)
-        # struct for device info
+
         async with self.lock:
-            _, cap_prop, _, event_rate = self.get_device_info_by_topic(topic=topic_str)
-            logger.debug("add message: cap_prop is: %s", cap_prop)
-            logger.debug("add message: event_rate: %s", event_rate)
+            info = self.device_registry.topic2info.get(topic_str)
+            if info is None:
+                logger.debug("Unknown topic %r, ignoring", topic_str)
+                return
+
+            device_id, cap_prop, idx, event_rate = info
             message = {
                 "topic": topic_str,
                 "cap_prop": cap_prop,
@@ -64,48 +89,99 @@ class AliceDeviceStateSender:
             }
             logger.debug("add message: message %s", message)
             self.buffers[topic_str].append(message)
-            # limits the size of the buffer (slice window)
+            # Limit buffer size (sliding window)
             if len(self.buffers[topic_str]) > MAX_BUFFER_SIZE:
                 self.buffers[topic_str] = self.buffers[topic_str][-MAX_BUFFER_SIZE:]
+
+            # Event property trigger immediate batch flush
+            blk = self.device_registry.devices[device_id][cap_prop][idx]
+            if blk.get("type", "").lower() == "devices.properties.event":
+                logger.debug("Event on %r, triggering batch flush", topic_str)
+                self.flush_event.set()
+
 
     async def send_to_yandex_loop(self):
         """
         Send message to yandex device
+        This is background loop: stage 1 (rate limiter) + stage 2 (batch flush)
         """
+        last_batch_time = time.time()
+
         while self.running:
             try:
                 current_time = time.time()
-                for topic, message_info in self.buffers.items():
-                    if not message_info:
-                        logger.debug("not message info for topic=%s", topic)
-                        continue
-                    last_send_time = self.last_send_times.get(topic, 0)
-                    # check time-rate
-                    if current_time - last_send_time > message_info[-1]["origin_rate"].time_rate:
-                        self.process_and_send_message(topic, message_info)
+                # --- Stage 1: Per-topic rate limiter ---
+                # Only pass topics whose time_rate elapsed, result goes to batch_buffer
+                async with self.lock:
+                    for topic, messages in self.buffers.items():
+                        if not messages:
+                            logger.debug("not message info for topic=%s", topic)
+                            continue
+                        last_send_time = self.last_send_times.get(topic, 0)
+                        rate = messages[-1]["origin_rate"].time_rate
+                        
+                        # check time-rate
+                        if current_time - last_send_time <= rate:
+                            continue  # Rate limit not passed yet
+
+                        # Rate limit passed → aggregate and convert
+                        aggregated = self.modify_messages_by_rule(
+                            rule=messages[-1]["origin_rate"].rule,
+                            messages=messages,
+                        )
+                        raw = str(aggregated["payload"])
+                        # send message to Yandex
+                        if os.getenv("__DEBUG__"):
+                            logger.info("[DEBUG] rate-passed: topic=%s, raw=%s", topic, raw)
+                        else:
+                            block = self.device_registry.convert_mqtt_to_yandex_block(
+                                topic=topic, raw=raw
+                            )
+                            if block is not None:
+                                self.batch_buffer.append(block)
+
                         self.buffers[topic].clear()
                         self.last_send_times[topic] = current_time
+
+                # --- Stage 2: Batch flush ---
+                batch_age = current_time - last_batch_time
+                should_flush = (
+                    self.batch_buffer
+                    and (batch_age >= BATCH_INTERVAL or self.flush_event.is_set())
+                )
+                if should_flush:
+                    self.flush_event.clear()
+                    merged = merge_device_blocks(self.batch_buffer)
+                    logger.debug(
+                        "Batch flush: %d block(s) → %d device(s)",
+                        len(self.batch_buffer), len(merged),
+                    )
+                    emit_batched_states(merged)
+                    self.batch_buffer.clear()
+                    last_batch_time = current_time
+
             except Exception as e:
                 logger.error("Error in send loop: %s", e, exc_info=True)
             await asyncio.sleep(0.1)
-        logger.info("send loop finished")
 
-    def process_and_send_message(self, topic: str, message_info: List[Dict]):
-        message_info = self.modify_messages_by_rule(
-            rule=message_info[-1]["origin_rate"].rule,
-            messages=message_info,
-        )
-        # send message to Yandex
-        if os.getenv("__DEBUG__"):
-            self.log_test_send(topic=topic, raw=message_info["payload"])
-        else:
-            self.device_registry.forward_mqtt_to_yandex(topic=topic, raw=message_info["payload"])
+        # Final flush on shutdown
+        if self.batch_buffer:
+            merged = merge_device_blocks(self.batch_buffer)
+            emit_batched_states(merged)
+            self.batch_buffer.clear()
+            logger.debug("Final flush on shutdown: %d device(s)", len(merged))
+
+        logger.info("send loop finished")
 
     def get_device_info_by_topic(self, topic):
         return self.device_registry.topic2info.get(topic)
 
     @staticmethod
     def modify_messages_by_rule(rule: str, messages: List[dict]):
+        """
+        Apply aggregation rule to buffered messages for one topic
+        Returns single message dict with aggregated payload
+        """
         if rule.lower() == "last_value":
             # last message value return
             return messages[-1]
@@ -126,6 +202,37 @@ class AliceDeviceStateSender:
         # process by default = last value
         return messages[-1]
 
-    @staticmethod
-    def log_test_send(topic: str, raw: str):
-        logger.info("log test send for %s : %s", topic, raw)
+def merge_device_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Merge multiple device state blocks by device_id
+
+    If the same device_id appears in multiple blocks (e.g. on_off and brightness
+    changed in the same batch window), their capabilities and properties lists
+    are concatenated into a single device entry
+    """
+    merged: Dict[str, Dict[str, Any]] = {}
+
+    for block in blocks:
+        device_id = block["id"]
+        if device_id not in merged:
+            merged[device_id] = {
+                "id": device_id,
+                "status": block.get("status", "online"),
+                "capabilities": [],
+                "properties": [],
+            }
+        if "capabilities" in block:
+            merged[device_id]["capabilities"].extend(block["capabilities"])
+        if "properties" in block:
+            merged[device_id]["properties"].extend(block["properties"])
+
+    # Remove empty lists before sending
+    result: List[Dict[str, Any]] = []
+    for device in merged.values():
+        if not device["capabilities"]:
+            del device["capabilities"]
+        if not device["properties"]:
+            del device["properties"]
+        result.append(device)
+
+    return result

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -124,7 +124,7 @@ class BatchDeviceStore:
 
         After this call, is_empty is True
         Uses reference swap: new writes go to a fresh dict,
-        result is built from the old one — safe if merge_block()
+        result is built from the old one - safe if merge_block()
         is called during _build_result() processing
         """
         with self._lock:
@@ -151,12 +151,12 @@ class AliceDeviceStateSender:
     """
     Two-stage sender for device state updates to Yandex Smart Home
 
-    Stage 1 — Per-topic rate limiter (existing logic):
+    Stage 1: Per-topic rate limiter (existing logic)
       Each topic has its own time_rate. Messages arriving faster than
       time_rate are buffered and aggregated (last_value / average_value)
       Only when time_rate has elapsed does the topic "pass" to stage 2
 
-    Stage 2 — Batch accumulator:
+    Stage 2: Batch accumulator
       Converted Yandex blocks from Stage 1 accumulate in BatchDeviceStore
       Flushed after BATCH_WINDOW_NORMAL or BATCH_WINDOW_FAST
       for time-sensitive types. Timer is managed by call_later.
@@ -259,7 +259,7 @@ class AliceDeviceStateSender:
         window = BATCH_WINDOW_FAST if time_sensitive else BATCH_WINDOW_NORMAL
 
         if self._flush_handle is None:
-            # No timer yet — schedule new one
+            # No timer yet - schedule new one
             self._current_window = window
             self._flush_handle = self._loop.call_later(window, self._do_flush)
             logger.debug("Flush scheduled in %.3fs (time_sensitive=%s)", window, time_sensitive)
@@ -275,7 +275,7 @@ class AliceDeviceStateSender:
     def _do_flush(self) -> None:
         """
         Timer callback: reset timer state and flush.
-        Called by loop.call_later — must be sync.
+        Called by loop.call_later - must be sync.
         """
         self._flush_handle = None
         self._current_window = 0.0

--- a/wb/mqtt_alice/client/wb_alice_device_state_sender.py
+++ b/wb/mqtt_alice/client/wb_alice_device_state_sender.py
@@ -24,6 +24,101 @@ logger = logging.getLogger(__name__)
 MAX_BUFFER_SIZE = int(getenv("MAX_BUFFER_SIZE", "10"))
 BATCH_INTERVAL = float(getenv("BATCH_INTERVAL", "1.0"))
 
+class BatchDeviceStore:
+    """
+    Deduplicated storage for device state blocks awaiting batch flush
+
+    Blocks are added and merged by device_id, capabilities and properties
+    are deduplicated by (type, instance) - only latest value is kept
+
+    Methods:
+        merge_block(block) - add or update a block
+        drain() - return merged list and clear storage
+        is_empty   - check if storage has data
+
+    Internal structure (self._devices):
+        {
+            "60ba5cbd-...-d7d7": {
+                "status": "online",
+                "capabilities": {
+                    ("devices.capabilities.on_off", "on"):
+                        {"type": "devices.capabilities.on_off",
+                         "state": {"instance": "on", "value": True}},
+                    ("devices.capabilities.range", "brightness"):
+                        {"type": "devices.capabilities.range",
+                         "state": {"instance": "brightness", "value": 75}},
+                },
+                "properties": {
+                    ("devices.properties.float", "temperature"):
+                        {"type": "devices.properties.float",
+                         "state": {"instance": "temperature", "value": 22.5}},
+                    ("devices.properties.event", "open"):
+                        {"type": "devices.properties.event",
+                         "state": {"instance": "open", "value": "opened"}},
+                },
+            },
+            "abc123-...-e2e3": {
+                "status": "online",
+                "capabilities": {},
+                "properties": {
+                    ("devices.properties.float", "temperature"):
+                        {"type": "devices.properties.float",
+                         "state": {"instance": "temperature", "value": -3.2}},
+                },
+            },
+        }
+    """
+
+    def __init__(self) -> None:
+        self._devices: Dict[str, Dict[str, Any]] = {}
+
+    def __len__(self) -> int:
+        """
+        Number of devices in storage
+        """
+        return len(self._devices)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._devices
+
+    def merge_block(self, block: Dict[str, Any]) -> None:
+        """
+        Merge block into storage with deduplication by (device_id, type, instance)
+        If same (type, instance) already exists for this device, value is overwritten
+        """
+        device_id = block["id"]
+        if device_id not in self._devices:
+            self._devices[device_id] = {
+                "status": block.get("status", "online"),
+                "capabilities": {},
+                "properties": {},
+            }
+        device = self._devices[device_id]
+        for cap in block.get("capabilities", []):
+            key = (cap["type"], cap["state"]["instance"])
+            device["capabilities"][key] = cap
+        for prop in block.get("properties", []):
+            key = (prop["type"], prop["state"]["instance"])
+            device["properties"][key] = prop
+
+    def drain(self) -> List[Dict[str, Any]]:
+        """
+        Return all accumulated devices as list and clear storage
+        After this call, is_empty is True
+        """
+        result: List[Dict[str, Any]] = []
+        for device_id, device in self._devices.items():
+            entry: Dict[str, Any] = {"id": device_id, "status": device["status"]}
+            caps = list(device["capabilities"].values())
+            props = list(device["properties"].values())
+            if caps:
+                entry["capabilities"] = caps
+            if props:
+                entry["properties"] = props
+            result.append(entry)
+        self._devices.clear()
+        return result
 
 class AliceDeviceStateSender:
     """
@@ -35,9 +130,9 @@ class AliceDeviceStateSender:
       Only when time_rate has elapsed does the topic "pass" to stage 2
 
     Stage 2 — Batch accumulator:
-      Converted Yandex blocks from stage 1 accumulate in batch_buffer
-      Flushed every BATCH_INTERVAL seconds or immediately when
-      an event property arrives. Blocks are merged by device_id
+      Converted Yandex blocks from Stage 1 accumulate in BatchDeviceStore
+      Flushed every BATCH_INTERVAL seconds or on event property arrival
+      Blocks are deduplicated by (device_id, type, instance)
     """
 
     def __init__(self, device_registry: DeviceRegistry):
@@ -47,30 +142,8 @@ class AliceDeviceStateSender:
         self.running = False
         self.device_registry = device_registry
 
-        # Batch accumulator for converted Yandex blocks
-        # Struct example:
-        # batch_buffer = [
-        #     # temperature
-        #     {
-        #         "id": "60ba5cbd-260128210608-79782ee3-c3a2-4143-9caf-ca83c523d7d7",
-        #         "status": "online",
-        #         "properties": [{
-        #             "type": "devices.properties.float",
-        #             "state": {"instance": "temperature", "value": 11.3}
-        #         }]
-        #     },
-        #     # First on_off
-        #     {
-        #         "id": "60ba5cbd-260128210608-79782ee3-c3a2-4143-9caf-ca83c523d7d7",
-        #         "status": "online",
-        #         "capabilities": [{
-        #             "type": "devices.capabilities.on_off",
-        #             "state": {"instance": "on", "value": True}
-        #         }]
-        #     },
-        # ]
-        self.batch_buffer: List[Dict[str, Any]] = []
         self.flush_event = asyncio.Event()
+        self._batch_store = BatchDeviceStore()
         self._task: Optional[asyncio.Task] = None
 
 
@@ -177,7 +250,7 @@ class AliceDeviceStateSender:
                         self.last_send_times[topic] = current_time
 
 
-                # Only pass topics whose time_rate elapsed, result goes to batch_buffer
+                # Only pass topics whose time_rate elapsed, result goes to _batch_store
                 # If All ok - send message to Yandex
                 for topic, aggregated_payload in topics_to_convert:
                     if os.getenv("__DEBUG__"):
@@ -187,7 +260,7 @@ class AliceDeviceStateSender:
                             topic=topic, raw=aggregated_payload
                         )
                         if block is not None:
-                            self.batch_buffer.append(block)
+                            self._batch_store.merge_block(block)
 
                             # Event property trigger immediate batch flush
                             if self._needs_immediate_flush(topic):
@@ -201,22 +274,24 @@ class AliceDeviceStateSender:
                 batch_age = current_time - last_batch_time
                 flush_triggered = self.flush_event.is_set()
                 should_flush = (
-                    self.batch_buffer
+                    not self._batch_store.is_empty
                     and (batch_age >= BATCH_INTERVAL or flush_triggered)
                 )
                 if should_flush:
                     self.flush_event.clear()
-                    merged = merge_device_blocks(self.batch_buffer)
                     logger.debug(
-                        "Batch flush: age=%.2fs, interval=%.1fs, event_trigger=%s, %d block(s) in %d device(s)",
+                        "Now will be flushed batch: age=%.2fs, interval=%.1fs, event_trigger=%s, %d block(s)",
                         batch_age,
                         BATCH_INTERVAL,
                         flush_triggered,
-                        len(self.batch_buffer),
+                        len(self._batch_store),
+                    )
+                    merged = self._batch_store.drain()
+                    logger.debug(
+                        "Batch flush: done - flushed %d device(s)",
                         len(merged),
                     )
                     emit_batched_states(merged)
-                    self.batch_buffer.clear()
                     last_batch_time = current_time
 
             except Exception as e:
@@ -224,10 +299,9 @@ class AliceDeviceStateSender:
             await asyncio.sleep(0.1)
 
         # Final flush on shutdown
-        if self.batch_buffer:
-            merged = merge_device_blocks(self.batch_buffer)
+        if not self._batch_store.is_empty:
+            merged = self._batch_store.drain()
             emit_batched_states(merged)
-            self.batch_buffer.clear()
             logger.debug("Final flush on shutdown: %d device(s)", len(merged))
 
         logger.info("send loop finished")
@@ -239,6 +313,8 @@ class AliceDeviceStateSender:
         Apply aggregation rule to buffered messages for one topic
         Returns single message dict with aggregated payload
         """
+        if not rule:
+            return messages[-1]
         if rule.lower() == "last_value":
             # last message value return
             return messages[-1]
@@ -258,46 +334,3 @@ class AliceDeviceStateSender:
             return message
         # process by default = last value
         return messages[-1]
-
-def merge_device_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """
-    Merge multiple device state blocks by device_id
-
-    If the same device_id appears in multiple blocks (e.g. on_off and brightness
-    changed in the same batch window), their capabilities and properties lists
-    are concatenated into a single device entry
-    """
-    merged: Dict[str, Dict[str, Any]] = {}
-
-    for block in blocks:
-        device_id = block["id"]
-        if device_id not in merged:
-            merged[device_id] = {
-                "id": device_id,
-                "status": block.get("status", "online"),
-                "capabilities": {},  # Keyed by (type, instance)
-                "properties": {},    # Keyed by (type, instance)
-            }
-        for cap in block.get("capabilities", []):
-            key = (cap["type"], cap["state"]["instance"])
-            merged[device_id]["capabilities"][key] = cap
-        for prop in block.get("properties", []):
-            key = (prop["type"], prop["state"]["instance"])
-            merged[device_id]["properties"][key] = prop
-
-    # Remove empty lists before sending
-    result: List[Dict[str, Any]] = []
-    for device in merged.values():
-        caps = list(device["capabilities"].values())
-        props = list(device["properties"].values())
-        if caps:
-            device["capabilities"] = caps
-        else:
-            del device["capabilities"]
-        if props:
-            device["properties"] = props
-        else:
-            del device["properties"]
-        result.append(device)
-
-    return result

--- a/wb/mqtt_alice/client/yandex_handlers.py
+++ b/wb/mqtt_alice/client/yandex_handlers.py
@@ -32,27 +32,27 @@ def set_emit_callback(callback: Callable[[str, Dict[str, Any]], None]) -> None:
     _emit_callback = callback
 
 
-def _on_off(device_id: str, instance: Optional[str], value: Any) -> None:
-    send_state_to_server(
+def _on_off(device_id: str, instance: Optional[str], value: Any) -> Dict[str, Any]:
+    return build_device_state_block(
         device_id, CAP_ON_OFF, instance, convert_to_bool(value)
     )
 
 
-def _float_prop(device_id: str, instance: Optional[str], value: Any) -> None:
-    send_state_to_server(
+def _float_prop(device_id: str, instance: Optional[str], value: Any) -> Dict[str, Any]:
+    return build_device_state_block(
         device_id, PROP_FLOAT, instance, convert_to_float(value)
     )
 
 
-def _range_cap(device_id: str, instance: Optional[str], value: Any) -> None:
-    send_state_to_server(
+def _range_cap(device_id: str, instance: Optional[str], value: Any) -> Dict[str, Any]:
+    return build_device_state_block(
         device_id, CAP_RANGE, instance, convert_to_float(value)
     )
 
 
-def _color_setting(device_id: str, instance: Optional[str], value: Any) -> None:
+def _color_setting(device_id: str, instance: Optional[str], value: Any) -> Optional[Dict[str, Any]]:
     """
-    Normilize instances to Yandex format:
+    Normalize instances to Yandex format:
       - rgb → instance='color', value=int(RGB)
       - temperature_k → instance='temperature_k', value=int
     """
@@ -64,11 +64,11 @@ def _color_setting(device_id: str, instance: Optional[str], value: Any) -> None:
             if rgb_int is None:
                 logger.warning("Failed to parse RGB value: %r", value)
                 return None
-        send_state_to_server(
+        return build_device_state_block(
             device_id, CAP_COLOR_SETTING, "rgb", rgb_int
         )
     elif instance == "temperature_k":
-        send_state_to_server(
+        return build_device_state_block(
             device_id,
             CAP_COLOR_SETTING,
             "temperature_k",
@@ -76,12 +76,14 @@ def _color_setting(device_id: str, instance: Optional[str], value: Any) -> None:
         )
     else:
         logger.debug("Unsupported instance %r — dropped", instance)
+        return None
     # HSV and color scene add there in future
 
 
-def _event_prop(device_id: str, instance: Optional[str], value: Any) -> None:
-    # Directly send event property to server, value is array of events
-    send_state_to_server(device_id, PROP_EVENT, instance, value)
+def _event_prop(device_id: str, instance: Optional[str], value: Any) -> Dict[str, Any]:
+    # Directly build event property block, value is array of events
+    return build_device_state_block(device_id, PROP_EVENT, instance, value)
+
 
 def _not_implemented(cap_type: str) -> Callable[..., None]:
     def _stub(*_a, **_kw) -> None:
@@ -90,7 +92,7 @@ def _not_implemented(cap_type: str) -> Callable[..., None]:
     return _stub
 
 
-# Yandex types handler table for select send logic from MQTT to Yandex
+# Yandex types handler table for select format logic from MQTT to Yandex
 _HANDLERS: Dict[str, Callable[[str, Optional[str], Any], None]] = {
     # Capabilities
     CAP_ON_OFF: _on_off,
@@ -124,18 +126,20 @@ def _build_state_block(
     return {key: [state_key]}
 
 
-def send_state_to_server(
+def build_device_state_block(
     device_id: str,
     block_type: str,
     instance: Optional[str],
     value: Any,
-) -> None:
+) -> Dict[str, Any]:
     """
-    Pushes **any** single capability / property
-    state update to the cloud proxy via Socket.IO
+    Build a device state block dict for a single capability/property update
+
+    Returns:
+        Dict with "id", "status", and one of "capabilities"/"properties" keys
     """
     logger.debug(
-        "[YANDEX] Sending state: device=%r, type=%r, instance=%r, value=%r",
+        "[YANDEX] Building state block: device=%r, type=%r, instance=%r, value=%r",
         device_id,
         block_type,
         instance,
@@ -150,35 +154,51 @@ def send_state_to_server(
     elif block_type.endswith("float"):
         value = convert_to_float(value)
 
+    return {
+        "id": device_id,
+        "status": "online",
+        **_build_state_block(
+            block_type,instance, value, is_property=is_prop
+        ),
+    }
+
+def emit_batched_states(devices: list) -> None:
+    """
+    Emit a batch of device state updates to the cloud proxy via Socket.IO
+    Called after collecting and merging device blocks
+
+    Args:
+        devices: List of device dicts, each with "id", "status",
+                 and "capabilities"/"properties" keys
+    """
+    if not devices:
+        return
+
     payload = {
         "ts": int(time.time()),
         "payload": {
             # user_id will be added by the proxy
-            "devices": [
-                {
-                    "id": device_id,
-                    "status": "online",
-                    **_build_state_block(
-                        block_type, instance, value, is_property=is_prop
-                    ),
-                }
-            ]
+            "devices": devices,
         },
     }
+    logger.debug("[YANDEX] Emitting batched state for %d device(s)", len(devices))
     try:
         if _emit_callback:
             _emit_callback("device_state", payload)
         else:
-            logger.warning("[YANDEX] Emit callback not set, dropping event")
+            logger.warning("[YANDEX] Emit callback not set, dropping batch")
     except Exception:
-        logging.exception("Error when processing MQTT message")
+        logging.exception("Error when emitting batched state")
 
 
-def send_to_yandex_state(
+def convert_to_yandex_block(
     device_id: str, cap_type: str, instance: Optional[str], value: Any
-) -> None:
+) -> Optional[Dict[str, Any]]:
     """
-    Unified sender to Yandex used by registry
+    Convert capability/property to Yandex device format state block
+    Used by DeviceRegistry as callback
+
+    Returns a device state block dict or None on error
     """
     handler = _HANDLERS.get(cap_type)
     if handler is None:
@@ -190,9 +210,10 @@ def send_to_yandex_state(
         return None
 
     try:
-        handler(device_id, instance, value)
+        return handler(device_id, instance, value)
     except NotImplementedError as err:
         # Explicit and loud: capability exists in table but lacks implementation
         logger.error("[YANDEX] %r", err)
     except Exception as exc:
         logger.exception("[YANDEX] Handler error for %r: %r", cap_type, exc)
+    return None


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

1) Добавлен батчинг нотификаций которые уходят яндексу
- Ивенты отправляются почти моментально, но для них оставлен быстрый батчинг с минимальным временем 100мс. Это время не существенно для человека но может сильно помочь серверу.
- Другие нотификации без ивентов копятся 1 секунду
- Если есть обычные события и приходит ивент, то время сокрашается до 100мс

2) Изменены настройки частоты обновления
- Для ивентов сделано 10мс (было 1с), тк должны отправляться мгновенно почти
- Для on_off поднято с 700 на 900мс
- Для других свойств и тд уменьшено с 1000мс до 900мс чтобы были меньше чем окно батчинга 1с
___________________________________
**Что поменялось для пользователей:**

Со стороны пользователей ивенты должны слаться почти мгновенно и сервер станет меньше нагружен, а следовательно и пользователям хорошо

___________________________________
**Как проверял/а:**

Локально устанавливал и проверял работу интеграции

