### PR TITLE
Remove cert and nginx logs after purge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.9.4) stable; urgency=medium
+
+  * Remove cert and nginx logs after purge
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 21 Apr 2026 15:10:00 +0400
+
 wb-mqtt-alice (0.9.3) stable; urgency=medium
 
   * Add batching for device state notifications to Yandex Smart Home:

--- a/debian/postrm
+++ b/debian/postrm
@@ -11,6 +11,8 @@ PACKET_NAME='wb-mqtt-alice'
 SITE_NAME="${PACKET_NAME}-proxy"
 SITE_CONFIG="/etc/nginx/sites-available/${SITE_NAME}"
 ENABLED_SITE="/etc/nginx/sites-enabled/${SITE_NAME}"
+NGINX_LOGS="/var/log/nginx/${PACKET_NAME}_*.log*"
+STATE_DIR="/var/lib/${PACKET_NAME}"
 
 # Global flag to track if any changes were made
 CHANGES_MADE='false'
@@ -27,14 +29,14 @@ log_warn() {
 
 cleanup_nginx_site() {
     log_info "Cleaning up nginx site configuration..."
-    
+
     # Remove enabled site symlink
     if [[ -L "${ENABLED_SITE}" ]]; then
         rm -f "${ENABLED_SITE}"
         log_info "Removed nginx site symlink: ${ENABLED_SITE}"
         CHANGES_MADE='true'
     fi
-    
+
     # Remove site configuration
     if [[ -f "${SITE_CONFIG}" ]]; then
         rm -f "${SITE_CONFIG}"
@@ -67,12 +69,16 @@ main() {
         log_info "Removed devices config: ${CONFFILE_DEVICES}"
         rm -f ${CONFFILE_DEVICES_DEFAULT}
         log_info "Removed default devices config: ${CONFFILE_DEVICES_DEFAULT}"
+        rm -f ${NGINX_LOGS}
+        log_info "Removed nginx logs: ${NGINX_LOGS}"
+        rm -rf "${STATE_DIR}"
+        log_info "Removed state dir: ${STATE_DIR}"
     fi
 
     # Note: we NOT remove SSL directive "ssl_engine ateccx08;" from nginx.conf
     # We can't guarantee they were added by us or not used elsewhere
     cleanup_nginx_site
-    
+
     # Only reload nginx if any changes were made
     if [ "${CHANGES_MADE}" = 'true' ]; then
         log_info "Changes were made, reloading nginx..."
@@ -80,7 +86,7 @@ main() {
     else
         log_info "No changes made, nginx reload skipped"
     fi
-    
+
     log_info "Cleanup completed successfully"
 }
 

--- a/debian/wb-mqtt-alice.dirs
+++ b/debian/wb-mqtt-alice.dirs
@@ -1,0 +1,1 @@
+/var/lib/wb-mqtt-alice


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

После purge пакета не все удаляется:
```sh
$ apt purge -y wb-mqtt-alice
$ find /var -name "*alice*" | grep -v /var/www
/var/lib/wb-mqtt-alice
/var/log/nginx/wb-mqtt-alice_error.log.2.gz
/var/log/nginx/wb-mqtt-alice_error.log.11.gz
/var/log/nginx/wb-mqtt-alice_error.log.4.gz
/var/log/nginx/wb-mqtt-alice_error.log.9.gz
/var/log/nginx/wb-mqtt-alice_error.log
/var/log/nginx/wb-mqtt-alice_error.log.7.gz
/var/log/nginx/wb-mqtt-alice_access.log
/var/log/nginx/wb-mqtt-alice_error.log.8.gz
/var/log/nginx/wb-mqtt-alice_error.log.14.gz
/var/log/nginx/wb-mqtt-alice_error.log.1
/var/log/nginx/wb-mqtt-alice_error.log.13.gz
/var/log/nginx/wb-mqtt-alice_error.log.10.gz
/var/log/nginx/wb-mqtt-alice_error.log.3.gz
/var/log/nginx/wb-mqtt-alice_error.log.6.gz
/var/log/nginx/wb-mqtt-alice_error.log.5.gz
/var/log/nginx/wb-mqtt-alice_error.log.12.gz
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на контроллере
