### PR TITLE
fix: update API endpoints for controller link status and registration INT-1002

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-alice (0.9.5) stable; urgency=medium
+wb-mqtt-alice (0.10.0) stable; urgency=medium
 
   * Switch the controller backend to the new server v1 controller link API
   * Split local Home UI endpoints into explicit link status and link creation actions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-mqtt-alice (0.9.5) stable; urgency=medium
+
+  * Switch the controller backend to the new server v1 controller link API
+  * Split local Home UI endpoints into explicit link status and link creation actions
+  * Decouple integration enablement from controller link status handling
+  * Require the new Home UI version for the updated Alice integration flow
+
+ -- Denis Smagin <denis.smagin@wirenboard.com>  Wed, 29 Apr 2026 12:00:00 +0200
+
 wb-mqtt-alice (0.9.4) stable; urgency=medium
 
   * Remove cert and nginx logs after purge

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.173.0~~),
+         wb-mqtt-homeui (>= 2.202.2~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.202.2~~),
+         wb-mqtt-homeui (>= 2.203.1~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.203.1~~),
+         wb-mqtt-homeui (>= 2.207.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),

--- a/wb/mqtt_alice/cli/main.py
+++ b/wb/mqtt_alice/cli/main.py
@@ -73,7 +73,9 @@ def unlink_controller():
             return ExitCode.UNLINK_FAILED
 
         response = fetch_url(
-            url=f"https://{server_address}/request-unlink",
+            url=f"https://{server_address}/api/v1/controller/link",
+            method="DELETE",
+            data={},
             key_id=key_id,
         )
 
@@ -126,8 +128,9 @@ def get_link_status():
             return ExitCode.INIT_ERROR
 
         response = fetch_url(
-            url=f"https://{server_address}/request-registration",
-            data={"controller_version": f"{controller_version}"},
+            url=f"https://{server_address}/api/v1/controller/link",
+            method="GET",
+            data=None,
             key_id=key_id,
         )
 
@@ -149,14 +152,12 @@ def get_link_status():
 
         data = response.get("data") or {}
 
-        # Controller is not linked if registration_url present or data is empty
-        if not data or ("registration_url" in data):
+        if isinstance(data, dict) and data.get("linked") is False:
             logger.info("%s not linked", CURRENT_LINK_STATUS_PREF)
             print("%s not linked" % CURRENT_LINK_STATUS_PREF)
             return ExitCode.STATUS_NOT_LINKED
 
-        # Controller linked if detail exists and is truthy
-        if isinstance(data, dict) and data.get("detail"):
+        if isinstance(data, dict) and data.get("linked") is True:
             logger.info("%s linked", CURRENT_LINK_STATUS_PREF)
             print("%s linked" % CURRENT_LINK_STATUS_PREF)
             return ExitCode.STATUS_LINKED

--- a/wb/mqtt_alice/client/main.py
+++ b/wb/mqtt_alice/client/main.py
@@ -342,7 +342,7 @@ def test_nginx_http_response(
       msg: str
     """
     method = "POST"
-    path = "/request-registration"
+    path = "/api/v1/controller/link"
     
     start_t = time.perf_counter()
     try:
@@ -400,7 +400,7 @@ async def probe_nginx_until_stable(
       can block 6–20s while DNS/TLS warms up
     - If we call sio.connect() in that window, it may hit its 10s timeout
       and we treat startup as failed
-    - So we "pre-flight" nginx here: POST /request-registration, expect fast
+    - So we "pre-flight" nginx here: POST /api/v1/controller/link, expect fast
       HTTP 422 (< acceptable_latency_s). We retry a few times until it's fast
 
     Returns:

--- a/wb/mqtt_alice/common/fetch_url.py
+++ b/wb/mqtt_alice/common/fetch_url.py
@@ -8,6 +8,7 @@ BUNDLE_CRT_PATH = "/var/lib/wb-mqtt-alice/device_bundle.crt.pem"
 
 def fetch_url(
     url=None,
+    method="POST",
     cert_path=BUNDLE_CRT_PATH,
     engine="ateccx08",
     key_type="ENG",
@@ -18,10 +19,11 @@ def fetch_url(
     retry_opts: Optional[Iterable[str]] = None,
     ):
     """
-    Performs an authenticated POST request via curl with a hardware key
+    Performs an authenticated HTTP request via curl with a hardware key
 
     Parameters:
         url (str): Target URL.
+        method (str): HTTP method.
         cert_path (str): Path to the SSL certificate.
         engine (str): Cryptographic engine.
         key_type (str): Key type.
@@ -67,7 +69,7 @@ def fetch_url(
     # Create a curl command
     cmd = [
         "curl",
-        "-X", "POST",
+        "-X", method.upper(),
         *retry_opts,
         "--cert", str(cert_path_obj),
         "--engine", engine,
@@ -84,7 +86,9 @@ def fetch_url(
         cmd.extend(["--header", f"{key}: {value}"])
 
     # Add JSON data and target URL
-    cmd.extend(["--data", json.dumps(data), url])
+    if method.upper() != "GET":
+        cmd.extend(["--data", json.dumps(data)])
+    cmd.append(url)
 
     try:
         # Execute command

--- a/wb/mqtt_alice/common/models.py
+++ b/wb/mqtt_alice/common/models.py
@@ -65,8 +65,11 @@ class Config(BaseModel):
 
 class ControllerLinkStatus(BaseModel):
     linked: bool
-    link_url: Optional[str] = None
-    unlink_url: Optional[str] = None
+    status_url: Optional[str] = None
+
+
+class ControllerLinkUrl(BaseModel):
+    link_url: str
 
 class ClientConfig(BaseModel):
     client_enabled: bool = False

--- a/wb/mqtt_alice/common/models.py
+++ b/wb/mqtt_alice/common/models.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 from pydantic import BaseModel
 from uuid import UUID
 
@@ -61,6 +61,10 @@ class RoomID(BaseModel):
 class Config(BaseModel):
     rooms: Dict[str, Room]
     devices: Dict[str, Device]
+
+
+class ControllerLinkStatus(BaseModel):
+    linked: bool
     link_url: Optional[str] = None
     unlink_url: Optional[str] = None
 

--- a/wb/mqtt_alice/config/main.py
+++ b/wb/mqtt_alice/config/main.py
@@ -17,8 +17,16 @@ from pydantic import ValidationError
 
 from wb.mqtt_alice.common.constants import CAP_COLOR_SETTING, CLIENT_CONFIG_PATH
 from wb.mqtt_alice.common.fetch_url import fetch_url
-from wb.mqtt_alice.common.models import (Capability, ClientConfig, Config, Device, Property, Room,
-                    RoomID)
+from wb.mqtt_alice.common.models import (
+    Capability,
+    ClientConfig,
+    Config,
+    ControllerLinkStatus,
+    Device,
+    Property,
+    Room,
+    RoomID,
+)
 from wb.mqtt_alice.common.wb_mqtt_load_config import (get_board_revision, get_key_id,
                                  load_server_config)
 
@@ -44,8 +52,6 @@ DEFAULT_LANGUAGE = "en"
 DEFAULT_CONFIG = {
     "rooms": {"without_rooms": {"name": "Без комнаты", "devices": []}},
     "devices": {},
-    "link_url": None,
-    "unlink_url": None,
 }
 
 # Global variables (will be initialized in init_globals())
@@ -358,47 +364,119 @@ def should_enable_client(config: Config) -> bool:
     return client_config.client_enabled
 
 
-def sync_registration_status(config: Config) -> Config:
+def get_unlink_base_url() -> str:
+    """Build the base URL used by Home UI for unlink actions."""
+    return f"https://{server_address.split(':')[0]}"
+
+
+def fetch_server_link_status(language: str = DEFAULT_LANGUAGE) -> ControllerLinkStatus:
     """
-    Synchronize controller registration status with remote server
-    
-    Updates config.link_url and config.unlink_url based on current registration state:
-    - If not registered: sets link_url (registration URL)
-    - If registered: sets unlink_url (server base URL)
-    
-    Args:
-        config: Current configuration object
-        
-    Returns:
-        Updated configuration object with actual registration URLs
+    Fetch explicit controller link status from the server v1 API.
     """
-    logger.debug("Synchronizing registration status with server...")
-    
-    try:
-        response = fetch_url(
-            url=f"https://{server_address}/request-registration",
-            data={"controller_version": f"{controller_version}"},
-            key_id=key_id,
+    response = fetch_url(
+        url=f"https://{server_address}/api/v1/controller/link",
+        method="GET",
+        data=None,
+        key_id=key_id,
+    )
+
+    if not isinstance(response, dict):
+        logger.error("Invalid link status response type: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_invalid_response", language),
         )
 
-        if response["data"] and "registration_url" in response["data"]:
-            # Controller is not registered - provide registration link
-            config.link_url = response["data"]["registration_url"]
-            config.unlink_url = None
-            logger.debug("Controller not registered, link_url updated")
-        elif response["data"]["detail"]:
-            # Controller is registered - provide unlink capability
-            config.link_url = None
-            config.unlink_url = f"https://{server_address.split(':')[0]}"
-            logger.debug("Controller registered, unlink_url updated")
+    status_code = int(response.get("status_code") or 0)
+    data = response.get("data")
 
-    except Exception as e:
-        logger.error("Failed to fetch registration URL: %r", e)
-        # On error, assume registered and provide unlink URL
-        config.link_url = None
-        config.unlink_url = f"https://{server_address.split(':')[0]}"
+    if status_code == 0:
+        logger.error("Link status request failed: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_unavailable", language),
+        )
 
-    return config
+    if status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        logger.error("Link status server error: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_unavailable", language),
+        )
+
+    if status_code >= HTTPStatus.BAD_REQUEST:
+        logger.error("Link status contract error: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_GATEWAY,
+            detail=get_translation("server_invalid_response", language),
+        )
+
+    if isinstance(data, dict) and isinstance(data.get("linked"), bool):
+        if data["linked"]:
+            return ControllerLinkStatus(linked=True, unlink_url=get_unlink_base_url())
+        return ControllerLinkStatus(linked=False)
+
+    logger.error("Link status payload is not recognized: %r", response)
+    raise HTTPException(
+        status_code=HTTPStatus.BAD_GATEWAY,
+        detail=get_translation("server_invalid_response", language),
+    )
+
+
+def build_controller_link_status(language: str = DEFAULT_LANGUAGE) -> ControllerLinkStatus:
+    """
+    Build normalized controller link status for local Home UI/backend usage.
+    """
+    link_status = fetch_server_link_status(language)
+    if link_status.linked:
+        return link_status
+
+    response = fetch_url(
+        url=f"https://{server_address}/api/v1/controller/link",
+        method="POST",
+        data={"controller_version": f"{controller_version}"},
+        key_id=key_id,
+    )
+
+    if not isinstance(response, dict):
+        logger.error("Invalid link creation response type: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_invalid_response", language),
+        )
+
+    status_code = int(response.get("status_code") or 0)
+    data = response.get("data")
+
+    if status_code == 0:
+        logger.error("Link creation request failed: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_unavailable", language),
+        )
+
+    if status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        logger.error("Link creation server error: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=get_translation("server_unavailable", language),
+        )
+
+    if status_code >= HTTPStatus.BAD_REQUEST:
+        logger.error("Link creation contract error: %r", response)
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_GATEWAY,
+            detail=get_translation("server_invalid_response", language),
+        )
+
+    if isinstance(data, dict) and data.get("link_url"):
+        return ControllerLinkStatus(linked=False, link_url=data["link_url"])
+
+    logger.error("Link creation payload is not recognized: %r", response)
+    raise HTTPException(
+        status_code=HTTPStatus.BAD_GATEWAY,
+        detail=get_translation("server_invalid_response", language),
+    )
 
 
 async def restore_client_status_if_needed(config: Config) -> None:
@@ -585,12 +663,21 @@ async def get_all_rooms_and_devices():
     """Get all the rooms and devices"""
 
     config = load_config()
-    config = sync_registration_status(config)
 
     # Don't force client reload because this doesn't change devices
     finalize_config_change(config, force_client_reload=False)
 
     return config
+
+
+@app.get(
+    "/integrations/alice/link_status",
+    response_model=ControllerLinkStatus,
+    status_code=HTTPStatus.OK,
+)
+async def get_link_status(request: Request):
+    """Return explicit controller link status for future Home UI versions."""
+    return build_controller_link_status(get_language(request))
 
 
 @app.get("/integrations/alice/available", status_code=HTTPStatus.OK)
@@ -783,7 +870,7 @@ async def change_device_room(request: Request, device_id: str, device_data: Room
 
 @app.post("/integrations/alice/enable_client", status_code=HTTPStatus.OK)
 async def enable_integration(request: Request):
-    """Enable Yandex Alice integration"""
+    """Enable or disable Yandex Alice integration independently from link status."""
 
     language = get_language(request)
     client_config = load_client_config()
@@ -791,55 +878,9 @@ async def enable_integration(request: Request):
     request_data = await request.json()
     requested_status = request_data.get("enabled", False)
 
-    # Update integration config
     client_config.client_enabled = requested_status
     save_client_config(client_config)
-
-    if requested_status:
-        # Use fetch_url to check current link status
-        try:
-            response = fetch_url(
-                url=f"https://{server_address}/request-registration",
-                data={"controller_version": f"{controller_version}"},
-                key_id=key_id,
-            )
-
-            # Validate response
-            if not isinstance(response, dict):
-                logger.error("Invalid response from server: %r", response)
-                raise HTTPException(
-                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
-                    detail=get_translation("server_unavailable", language),
-                )
-
-            data = response.get("data", {})
-
-            # Controller not linked if registration_url present or data empty
-            if not data or ("registration_url" in data):
-                raise HTTPException(
-                    status_code=HTTPStatus.PRECONDITION_FAILED,
-                    detail=get_translation("controller_not_linked", language),
-                )
-
-            # Controller linked if detail exists
-            if not (isinstance(data, dict) and data.get("detail")):
-                raise HTTPException(
-                    status_code=HTTPStatus.PRECONDITION_FAILED,
-                    detail=get_translation("controller_status_unknown", language),
-                )
-
-        except HTTPException:
-            raise  # Re-raise HTTP exceptions
-        except Exception as e:
-            logger.error("Failed to check controller link status: %r", e)
-            raise HTTPException(
-                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
-                detail=get_translation("server_unavailable", language),
-            )
-        finally:
-            force_client_reload_config()
-    else:
-        force_client_reload_config()
+    force_client_reload_config()
     return {"message": get_translation("integration_enabled", language)}
 
 
@@ -863,7 +904,9 @@ async def unlink_controller(request: Request):
 
     try:
         response = fetch_url(
-            url=f"https://{server_address}/request-unlink",
+            url=f"https://{server_address}/api/v1/controller/link",
+            method="DELETE",
+            data={},
             key_id=key_id,
         )
         logger.info("response: %r", response)
@@ -951,7 +994,6 @@ async def startup_event():
     init_globals()
     config = load_config()
 
-    config = sync_registration_status(config)
     finalize_config_change(config, force_client_reload=False)
     
     await restore_client_status_if_needed(config)

--- a/wb/mqtt_alice/config/main.py
+++ b/wb/mqtt_alice/config/main.py
@@ -22,6 +22,7 @@ from wb.mqtt_alice.common.models import (
     ClientConfig,
     Config,
     ControllerLinkStatus,
+    ControllerLinkUrl,
     Device,
     Property,
     Room,
@@ -413,7 +414,7 @@ def fetch_server_link_status(language: str = DEFAULT_LANGUAGE) -> ControllerLink
 
     if isinstance(data, dict) and isinstance(data.get("linked"), bool):
         if data["linked"]:
-            return ControllerLinkStatus(linked=True, unlink_url=get_unlink_base_url())
+            return ControllerLinkStatus(linked=True, status_url=get_unlink_base_url())
         return ControllerLinkStatus(linked=False)
 
     logger.error("Link status payload is not recognized: %r", response)
@@ -423,14 +424,10 @@ def fetch_server_link_status(language: str = DEFAULT_LANGUAGE) -> ControllerLink
     )
 
 
-def build_controller_link_status(language: str = DEFAULT_LANGUAGE) -> ControllerLinkStatus:
+def create_controller_link(language: str = DEFAULT_LANGUAGE) -> ControllerLinkUrl:
     """
-    Build normalized controller link status for local Home UI/backend usage.
+    Create or fetch an explicit controller registration link.
     """
-    link_status = fetch_server_link_status(language)
-    if link_status.linked:
-        return link_status
-
     response = fetch_url(
         url=f"https://{server_address}/api/v1/controller/link",
         method="POST",
@@ -470,7 +467,7 @@ def build_controller_link_status(language: str = DEFAULT_LANGUAGE) -> Controller
         )
 
     if isinstance(data, dict) and data.get("link_url"):
-        return ControllerLinkStatus(linked=False, link_url=data["link_url"])
+        return ControllerLinkUrl(link_url=data["link_url"])
 
     logger.error("Link creation payload is not recognized: %r", response)
     raise HTTPException(
@@ -676,8 +673,18 @@ async def get_all_rooms_and_devices():
     status_code=HTTPStatus.OK,
 )
 async def get_link_status(request: Request):
-    """Return explicit controller link status for future Home UI versions."""
-    return build_controller_link_status(get_language(request))
+    """Return pure controller link status without side effects."""
+    return fetch_server_link_status(get_language(request))
+
+
+@app.post(
+    "/integrations/alice/link",
+    response_model=ControllerLinkUrl,
+    status_code=HTTPStatus.OK,
+)
+async def create_link(request: Request):
+    """Create a controller registration link for Home UI."""
+    return create_controller_link(get_language(request))
 
 
 @app.get("/integrations/alice/available", status_code=HTTPStatus.OK)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

[INT-1002](https://wirenboard.youtrack.cloud/issue/INT-1002/Neochevidnoe-povedenie-Alice-Config-pri-padenii-ostanovke-proxyapp)

Переводит клиентский сервис на новый server API и делает локальный backend-контракт для HomeUI более явным и предсказуемым.

- Клиент переведён на новый серверный endpoint /api/v1/controller/link
- Локальный GET /integrations/alice/link_status теперь стал чистым status endpoint без побочных эффектов
- Добавлен отдельный POST /integrations/alice/link для явного получения ссылки на привязку
- Логика включения интеграции отделена от логики проверки статуса привязки
- Сохранён локальный backend-слой между HomeUI и Alice server, чтобы фронт не зависел напрямую от серверного API

[PR wb-mqtt-alice-server](https://github.com/wirenboard/wb-mqtt-alice-server/pull/63)
[PR homeui](https://github.com/wirenboard/homeui/pull/1066)
___________________________________
**Что поменялось для пользователей:**

Более явный статус и логика его получения

___________________________________
**Как проверял/а:**

Установил деб пакет на контроллере и протестировал с дев сервером
