### PR TITLE
feat: add support toggle capability to client INT-933

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.11.0) stable; urgency=medium
+
+  * Add support for Yandex Smart Home toggle capability
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Tue, 19 May 2026 15:00:00 +0300
+
 wb-mqtt-alice (0.10.1) stable; urgency=medium
 
   * Add static analysis to the project and CI pipeline

--- a/wb/mqtt_alice/client/device_registry.py
+++ b/wb/mqtt_alice/client/device_registry.py
@@ -579,7 +579,7 @@ class DeviceRegistry:
         # Use empty dict if None provided
         params = params or {}
 
-        if cap_type.endswith("on_off"):
+        if cap_type.endswith("on_off") or cap_type.endswith("toggle"):
             return convert_to_bool(raw)
 
         elif cap_type.endswith("float") or cap_type.endswith("range"):
@@ -714,7 +714,7 @@ class DeviceRegistry:
         """
         params = params or {}
 
-        if cap_type.endswith("on_off"):
+        if cap_type.endswith("on_off") or cap_type.endswith("toggle"):
             return "1" if value else "0"
 
         elif cap_type.endswith("color_setting"):

--- a/wb/mqtt_alice/client/yandex_handlers.py
+++ b/wb/mqtt_alice/client/yandex_handlers.py
@@ -46,6 +46,10 @@ def _range_cap(device_id: str, instance: Optional[str], value: Any) -> Dict[str,
     return build_device_state_block(device_id, CAP_RANGE, instance, convert_to_float(value))
 
 
+def _toggle_cap(device_id: str, instance: Optional[str], value: Any) -> Dict[str, Any]:
+    return build_device_state_block(device_id, CAP_TOGGLE, instance, convert_to_bool(value))
+
+
 def _color_setting(device_id: str, instance: Optional[str], value: Any) -> Optional[Dict[str, Any]]:
     """
     Normalize instances to Yandex format:
@@ -94,7 +98,7 @@ _HANDLERS: Dict[str, Callable[[str, Optional[str], Any], None]] = {
     CAP_VIDEO_STREAM: _not_implemented("cap.video_stream"),
     CAP_MODE: _not_implemented("cap.mode"),
     CAP_RANGE: _range_cap,
-    CAP_TOGGLE: _not_implemented("cap.toggle"),
+    CAP_TOGGLE: _toggle_cap,
     # Properties
     PROP_FLOAT: _float_prop,
     PROP_EVENT: _event_prop,
@@ -143,7 +147,7 @@ def build_device_state_block(
     is_prop = block_type.startswith("devices.properties")
 
     # Normalize known value types
-    if block_type.endswith("on_off"):
+    if block_type.endswith("on_off") or block_type.endswith("toggle"):
         value = convert_to_bool(value)
     elif block_type.endswith("float"):
         value = convert_to_float(value)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Это минимальные изменения для добавления toggle в текущего клиента

Со стороны UI было изменение связанное тут
https://github.com/wirenboard/homeui/pull/1082

UI отдает клиенту такой конфиг
```
root@wirenboard-AQLNJER2:~# cat /etc/wb-mqtt-alice-devices.conf
{
  "rooms": {
    "without_rooms": {
      "name": "Без комнаты",
      "devices": [
        "60ba5cbd-260513132728-035fa58c-0ce5-4738-8d3c-5dbbddaa686b"
      ]
    }
  },
  "devices": {
    "60ba5cbd-260513132728-035fa58c-0ce5-4738-8d3c-5dbbddaa686b": {
      "name": "Лампачка",
      "status_info": null,
      "description": null,
      "room_id": "without_rooms",
      "type": "devices.types.sensor",
      "capabilities": [
        {
          "type": "devices.capabilities.on_off",
          "mqtt": "buzzer/enabled",
          "parameters": {
            "instance": "on"
          }
        },
        {
          "type": "devices.capabilities.toggle",
          "mqtt": "buzzer/enabled",
          "parameters": {
            "instance": "backlight"
          }
        }
      ],
      "properties": []
    }
  }
}

root@wirenboard-AQLNJER2:~#
```

В итоге - в Алисе это отображается так
<img width="718" height="716" alt="image" src="https://github.com/user-attachments/assets/eb69d6f0-4c30-4f2e-8503-6d1ae8c10e40" />

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


