### PR TITLE
docs: change min req version for homeui in deps INT-933

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.11.1) stable; urgency=medium
+
+  * Change min version for homeui
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Wed, 20 May 2026 20:00:00 +0300
+
 wb-mqtt-alice (0.11.0) stable; urgency=medium
 
   * Add support for Yandex Smart Home toggle capability

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.207.0~~),
+         wb-mqtt-homeui (>= 2.213.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Поднял версию, так как есть залитые изменения в homeui

Связанный PR фронта
https://github.com/wirenboard/homeui/pull/1082
___________________________________
**Что поменялось для пользователей:**

Теперь не получится установить версию homeui ниже нужной для toggle

___________________________________
**Как проверял/а:**


