### PR TITLE
chore: update dependency version for wb-mqtt-homeui INT-1028

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.12.1) stable; urgency=medium
+
+  * Change min version for homeui
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Thu, 04 Jun 2026 20:00:00 +0300
+
 wb-mqtt-alice (0.12.0) stable; urgency=medium
 
   * Add support for Yandex Smart Home mode capability

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.213.0~~),
+         wb-mqtt-homeui (>= 2.219.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Изменениа минимальная необходимая версия homeui, тк добавили modes

Связанный PR в homeui
https://github.com/wirenboard/homeui/pull/1091

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


