### PR TITLE
fix: set proxy_ssl_verify_depth for certificate chain INT-1140

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-alice (0.13.1) stable; urgency=medium
+
+  * Fix nginx 502 caused by upstream "certificate chain too long" - set
+    proxy_ssl_verify_depth to accept the current alice.wirenboard.com cert chain
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Fri, 19 Jun 2026 15:00:00 +0300
+
 wb-mqtt-alice (0.13.0) stable; urgency=medium
 
   * Add support for split parameter on on_off capability

--- a/scripts/configure-nginx-proxy.sh
+++ b/scripts/configure-nginx-proxy.sh
@@ -358,6 +358,10 @@ server {
         proxy_ssl_protocols TLSv1.3;
         proxy_ssl_verify on;
 
+        # Max length of the alice.wirenboard.com cert chain that nginx will trust
+        # If nginx error log shows "certificate chain too long" - bump this value by 1
+        proxy_ssl_verify_depth 2;
+
         # Off: use hardware key on every TLS handshake
         #      - slower, ~0.7s per handshake
         #      - some old or non-standard servers may work only with "off"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Lets encrypt обновил сертификаты нашему домену и клиент перестал доверять ему, тк цепочка увеличилась с 1 до 2
Добавили переменную в код где дли на увеличена с 1 до 2 явно - раньше использовалось дефолтное значение 1

___________________________________
**Что поменялось для пользователей:**

Не будет ошибки

___________________________________
**Как проверял/а:**

Локально на контроллере воспроизвел, потом пофиксил и соединилось

До обновления не конектилось

<img width="1367" height="894" alt="image" src="https://github.com/user-attachments/assets/06ae9ac6-0477-486c-ad67-2edbf8542bde" />


После обновления на новую версию видим изменения
<img width="1084" height="517" alt="image" src="https://github.com/user-attachments/assets/b9b03225-9f49-42cb-b705-b27603e681ed" />

Подключается с 1 попытки
<img width="1151" height="491" alt="image" src="https://github.com/user-attachments/assets/1ffe4f52-991b-4681-8966-ea45d3572ade" />
