### PR TITLE
chore: change min version for homeui in changelog INT-941

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.13.2) stable; urgency=medium
+
+  * Change min version for homeui
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Mon, 22 Jun 2026 11:00:00 +0300
+
 wb-mqtt-alice (0.13.1) stable; urgency=medium
 
   * Fix nginx 502 caused by upstream "certificate chain too long" - set

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
-         wb-mqtt-homeui (>= 2.219.0~~),
+         wb-mqtt-homeui (>= 2.228.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Изменена версия минимального Homeui - теперь там есть возможности настройки уведомлений, запроса состояний и раздельных кнопок on-off

Связаный PR
https://github.com/wirenboard/homeui/pull/1108

___________________________________
**Что поменялось для пользователей:**

Теперь версии клиента и homeui синхронизированы по возможностям

___________________________________
**Как проверял/а:**


