### PR TITLE
fix: add curl dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-alice (0.13.4) stable; urgency=medium
+
+  * Fix curl dependency (OpenSSL ENGINE support is broken in curl >= 8.14.0 and < 8.15.0)
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 30 Jul 2026 17:10:00 +0400
+
 wb-mqtt-alice (0.13.3) stable; urgency=medium
 
   * Fix relative range commands - the increment from Yandex was set as the value

--- a/debian/control
+++ b/debian/control
@@ -17,13 +17,14 @@ Section: python
 Architecture: all
 Depends: ${misc:Depends},
          jq,
+         curl (>= 8.15.0),
          wb-mqtt-homeui (>= 2.228.0~~),
          ${python3:Depends},
          python3-fastapi (>= 0.63.0),
          python3-requests (>= 2.25.1),
          python3-uvicorn (>= 0.13.3),
          python3-socketio (>= 5.0.3),
-         python3-websocket (>= 0.57.0)  | python3-websocket-client,
+         python3-websocket (>= 0.57.0) | python3-websocket-client,
          python3-aiohttp (>= 3.7.4),
          python3-paho-mqtt (>= 1.5.1)
 Description: Yandex smart home with Alice to MQTT for Wiren Board controllers


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
curl >= 8.15.0 доступен только в trixie-backports, нужно чтобы избежать установку с curl 8.14.1 из основной trixie репы, с которой заведомо работать не будет

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


